### PR TITLE
Fix Mermaid node CSS collision by namespacing card classes to .ve-card

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -68,6 +68,8 @@ Vary the choice each time. If the last diagram was dark and technical, make the 
 
 **Mermaid zoom controls:** Always add zoom controls (+/−/reset buttons) to every `.mermaid-wrap` container. Complex diagrams render at small sizes and need zoom to be readable. Include Ctrl/Cmd+scroll zoom on the container. See the zoom controls pattern in `./references/css-patterns.md` and the reference template at `./templates/mermaid-flowchart.html`.
 
+**Mermaid CSS class collision constraint:** Never define `.node` as a page-level CSS class. Mermaid.js uses `.node` internally on SVG `<g>` elements with `transform: translate(x, y)` for positioning. Page-level `.node` styles (hover transforms, box-shadows) leak into diagrams and break layout. Use the namespaced `.ve-card` class for card components instead. The only safe way to style Mermaid's `.node` is scoped under `.mermaid` (e.g., `.mermaid .node rect`).
+
 **AI-generated illustrations (optional).** If [surf-cli](https://github.com/nicobailon/surf-cli) is available, you can generate images via Gemini and embed them in the page for creative, illustrative, explanatory, educational, or decorative purposes. Check availability with `which surf`. If available:
 
 ```bash
@@ -115,7 +117,7 @@ Apply these principles to every diagram:
 
 **Visual weight signals importance.** Not every section deserves equal visual treatment. Executive summaries and key metrics should dominate the viewport on load (larger type, more padding, subtle accent-tinted background zone). Reference sections (file maps, dependency lists, decision logs) should be compact and stay out of the way. Use `<details>/<summary>` for sections that are useful but not primary — the collapsible pattern is in `./references/css-patterns.md`.
 
-**Surface depth creates hierarchy.** Vary card depth to signal what matters. Hero sections get elevated shadows and accent-tinted backgrounds (`node--hero` pattern). Body content stays flat (default `.node`). Code blocks and secondary content feel recessed (`node--recessed`). See the depth tiers in `./references/css-patterns.md`. Don't make everything elevated — when everything pops, nothing does.
+**Surface depth creates hierarchy.** Vary card depth to signal what matters. Hero sections get elevated shadows and accent-tinted backgrounds (`ve-card--hero` pattern). Body content stays flat (default `.ve-card`). Code blocks and secondary content feel recessed (`ve-card--recessed`). See the depth tiers in `./references/css-patterns.md`. Don't make everything elevated — when everything pops, nothing does.
 
 **Animation earns its place.** Staggered fade-ins on page load are almost always worth it — they guide the eye through the diagram's hierarchy. Mix animation types by role: `fadeUp` for cards, `fadeScale` for KPIs and badges, `drawIn` for SVG connectors, `countUp` for hero numbers. Hover transitions on interactive-feeling elements make the diagram feel alive. Always respect `prefers-reduced-motion`. CSS transitions and keyframes handle most cases. For orchestrated multi-element sequences, anime.js via CDN is available (see `./references/libraries.md`).
 

--- a/references/css-patterns.md
+++ b/references/css-patterns.md
@@ -86,12 +86,14 @@ body {
 }
 ```
 
-## Section / Node Cards
+## Section / Card Components
 
 The fundamental building block. A colored card representing a system component, pipeline step, or data entity.
 
+**IMPORTANT: Never use `.node` as a CSS class name.** Mermaid.js internally uses `.node` on its SVG `<g>` elements with `transform: translate(x, y)` for positioning. Any page-level `.node` styles (hover transforms, box-shadows, transitions) will leak into Mermaid diagrams and break their layout. Use `.ve-card` instead (namespaced to avoid collisions with CSS frameworks like Bootstrap/Tailwind that also use `.card`).
+
 ```css
-.node {
+.ve-card {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -100,34 +102,34 @@ The fundamental building block. A colored card representing a system component, 
 }
 
 /* Colored accent border (left or top) */
-.node--accent-a {
+.ve-card--accent-a {
   border-left: 3px solid var(--node-a);
 }
 
 /* --- Depth tiers: vary card depth to signal importance --- */
 
 /* Elevated: KPIs, key sections, anything that should pop */
-.node--elevated {
+.ve-card--elevated {
   background: var(--surface-elevated);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 /* Recessed: code blocks, secondary content, detail panels */
-.node--recessed {
+.ve-card--recessed {
   background: color-mix(in srgb, var(--bg) 70%, var(--surface) 30%);
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
   border-color: var(--border);
 }
 
 /* Hero: executive summaries, focal elements — demands attention */
-.node--hero {
+.ve-card--hero {
   background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
   border-color: color-mix(in srgb, var(--border) 50%, var(--accent) 50%);
 }
 
 /* Glass: special-occasion overlay effect (use sparingly) */
-.node--glass {
+.ve-card--glass {
   background: color-mix(in srgb, var(--surface) 60%, transparent 40%);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -135,7 +137,7 @@ The fundamental building block. A colored card representing a system component, 
 }
 
 /* Section label (monospace, uppercase, small) */
-.node__label {
+.ve-card__label {
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 600;
@@ -149,7 +151,7 @@ The fundamental building block. A colored card representing a system component, 
 }
 
 /* Colored dot indicator */
-.node__label::before {
+.ve-card__label::before {
   content: '';
   width: 8px;
   height: 8px;
@@ -701,7 +703,7 @@ Define the keyframe once, then stagger via a `--i` CSS variable set per element.
   to { opacity: 1; transform: translateY(0); }
 }
 
-.node {
+.ve-card {
   animation: fadeUp 0.4s ease-out both;
   animation-delay: calc(var(--i, 0) * 0.05s);
 }
@@ -710,20 +712,20 @@ Define the keyframe once, then stagger via a `--i` CSS variable set per element.
 Set `--i` per element in the HTML to control stagger order:
 
 ```html
-<div class="node" style="--i: 0">First</div>
+<div class="ve-card" style="--i: 0">First</div>
 <div class="connector">...</div>
-<div class="node" style="--i: 1">Second</div>
+<div class="ve-card" style="--i: 1">Second</div>
 <div class="connector">...</div>
-<div class="node" style="--i: 2">Third</div>
+<div class="ve-card" style="--i: 2">Third</div>
 ```
 
 ### Hover Lift
 ```css
-.node {
+.ve-card {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.node:hover {
+.ve-card:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }

--- a/references/libraries.md
+++ b/references/libraries.md
@@ -403,7 +403,7 @@ Use when a diagram has 10+ elements and you want a choreographed entrance sequen
 
   if (!prefersReduced) {
     anime({
-      targets: '.node',
+      targets: '.ve-card',
       opacity: [0, 1],
       translateY: [20, 0],
       delay: anime.stagger(80, { start: 200 }),
@@ -436,10 +436,10 @@ Use when a diagram has 10+ elements and you want a choreographed entrance sequen
 
 When using anime.js, set initial opacity to 0 in CSS so elements don't flash before the animation:
 ```css
-.node { opacity: 0; }
+.ve-card { opacity: 0; }
 
 @media (prefers-reduced-motion: reduce) {
-  .node { opacity: 1 !important; }
+  .ve-card { opacity: 1 !important; }
 }
 ```
 


### PR DESCRIPTION
## Summary

This fixes a CSS class collision between visual-explainer card components and Mermaid's internal `.node` class.

When a page includes both Mermaid diagrams and card components, page-level `.node` styles (e.g. hover transforms, shadows, transitions) leak into Mermaid SVG `<g>` groups and break diagram layout — nodes collapse to origin because `transform: translate(x, y)` gets overridden.

## Changes

- Renamed card component selectors from `.node` to `.ve-card` in `references/css-patterns.md`:
  - `.ve-card`, `.ve-card--accent-a`, `.ve-card--elevated`, `.ve-card--recessed`, `.ve-card--hero`, `.ve-card--glass`
  - `.ve-card__label`, `.ve-card__label::before`
- Updated animation examples in `references/libraries.md` to target `.ve-card`
- Added an explicit hard constraint in `SKILL.md` Mermaid guidance:
  - Never define `.node` as a page-level CSS class
  - Only style Mermaid nodes when scoped under `.mermaid` (e.g. `.mermaid .node rect`)
- Namespaced as `.ve-card` (not `.card`) to also avoid collisions with Bootstrap/Tailwind which use `.card`

## Impact

Affects all users who mix Mermaid diagrams with card-based components in generated pages — which is the primary use case for this skill. Without this fix, any page using both Mermaid and the `.node` card pattern will have broken diagram rendering.

## Reproduction

1. Generate a page using the architecture card pattern (`.node`) alongside a Mermaid `graph TD` diagram
2. Observe that Mermaid nodes are mispositioned (all collapsed to origin) and hover effects break diagram interactivity
3. After this fix, `.ve-card` no longer collides with Mermaid's internal `.node` class