### PR TITLE
fix: scope pi skills to SKILL.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": ["pi-package"],
   "license": "MIT",
   "pi": {
-    "skills": ["./"],
+    "skills": ["./SKILL.md"],
     "prompts": ["./prompts"]
   }
 }


### PR DESCRIPTION
When installing it looks like `pi` is trying to evaluate `README.md and CHANGELOG.md` as skill files. This PR fixes Pi skill-loading conflicts by narrowing the package’s skill manifest from `./` to `./SKILL.md`.

<img width="550" height="153" alt="Screenshot 2026-02-25 at 7 22 29 AM" src="https://github.com/user-attachments/assets/83593bd7-f5af-4558-abb3-cf12117d5df6" />

Thanks for the great tool! Apologies in advance if I've misunderstood this.