### PR TITLE
fix: ignore root docs in skill package scan

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+README.md
+CHANGELOG.md


### PR DESCRIPTION
## Why
Pi currently discovers root-level markdown files in skill packages. In this package, `README.md` and `CHANGELOG.md` were being parsed as skills, which triggered `description is required` conflicts during skill loading.

## What Changed
- Added a root `.ignore` file to skip these non-skill docs during package scanning:
  - `README.md`
  - `CHANGELOG.md`

This keeps the package's `SKILL.md` discovery intact while preventing accidental skill parsing of general docs.

## Validation
- Verified by loading from directory and confirming only `SKILL.md` is discovered as a skill.
