### PR TITLE
docs: add prompt template install instructions for Claude Code and Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you prefer a manual install, clone the repo and copy the prompts:
 
 ```bash
 git clone https://github.com/nicobailon/visual-explainer.git ~/.pi/agent/skills/visual-explainer
+mkdir -p ~/.pi/agent/prompts
 cp ~/.pi/agent/skills/visual-explainer/prompts/*.md ~/.pi/agent/prompts/
 ```
 
@@ -48,6 +49,7 @@ Clone the skill, then copy the prompt templates so they register as slash comman
 
 ```bash
 git clone https://github.com/nicobailon/visual-explainer.git ~/.claude/skills/visual-explainer
+mkdir -p ~/.claude/commands
 cp ~/.claude/skills/visual-explainer/prompts/*.md ~/.claude/commands/
 ```
 


### PR DESCRIPTION
The install section was missing instructions for copying prompt templates
to the directories where each agent registers slash commands:
- Claude Code: ~/.claude/commands/
- Pi (manual): ~/.pi/agent/prompts/

Also adds a manual install path for Pi alongside the existing `pi install`.

https://claude.ai/code/session_019PYyW4ZpfWhLocWBYnypzw