### PR TITLE
docs: add OpenAI Codex install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ mkdir -p ~/.claude/commands
 cp ~/.claude/skills/visual-explainer/prompts/*.md ~/.claude/commands/
 ```
 
+**OpenAI Codex:**
+```bash
+git clone https://github.com/nicobailon/visual-explainer.git ~/.agents/skills/visual-explainer
+mkdir -p ~/.agents/commands
+cp ~/.agents/skills/visual-explainer/prompts/*.md ~/.agents/commands/
+```
+
 ## Commands
 
 | Command | What it does |


### PR DESCRIPTION
## Summary
- keeps the existing **Claude Code** install instructions unchanged
- adds a new **OpenAI Codex** install section under Install
- documents the `~/.agents/skills` and `~/.agents/commands` paths

## Testing
- docs-only change (no runtime changes)