### PR TITLE
fix: clarify Mermaid line breaks in flowchart labels: `\n` => `<br/>`

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -86,6 +86,8 @@ Vary the choice each time. If the last diagram was dark and technical, make the 
 
 **Mermaid layout direction:** Prefer `flowchart TD` (top-down) over `flowchart LR` (left-to-right) for complex diagrams. LR spreads horizontally and makes labels unreadable when there are many nodes. Use LR only for simple 3-4 node linear flows. See `./references/libraries.md` "Layout Direction: TD vs LR".
 
+**Mermaid line breaks in flowchart labels:** Use `<br/>` inside quoted labels. Never use escaped newlines like `\n` (Mermaid renders them as literal text in HTML output). Example: `A["Copilot Backend<br/>/api + /api/voicebot"]`.
+
 **Mermaid CSS class collision constraint:** Never define `.node` as a page-level CSS class. Mermaid.js uses `.node` internally on SVG `<g>` elements with `transform: translate(x, y)` for positioning. Page-level `.node` styles (hover transforms, box-shadows) leak into diagrams and break layout. Use the namespaced `.ve-card` class for card components instead. The only safe way to style Mermaid's `.node` is scoped under `.mermaid` (e.g., `.mermaid .node rect`).
 
 **AI-generated illustrations (optional).** If [surf-cli](https://github.com/nicobailon/surf-cli) is available, you can generate images via Gemini and embed them in the page for creative, illustrative, explanatory, educational, or decorative purposes. Check availability with `which surf`. If available:

--- a/references/libraries.md
+++ b/references/libraries.md
@@ -203,6 +203,16 @@ If you need multi-line labels or special characters, use a `flowchart` instead o
 
 Most Mermaid failures come from a few recurring issues. Follow these rules to avoid invalid diagrams:
 
+**For multi-line flowchart node labels, use `<br/>` (not `\n`).** Mermaid flowcharts interpret `<br/>` as a line break, but escaped `\n` in labels often renders as literal text:
+
+```
+%% WRONG — renders literal "\n" in node text
+A["Copilot Backend\n/api + /api/voicebot"] --> B["Redis"]
+
+%% RIGHT — renders on two lines
+A["Copilot Backend<br/>/api + /api/voicebot"] --> B["Redis"]
+```
+
 **Quote labels with special characters.** Parentheses, colons, commas, brackets, and ampersands break the parser when unquoted. Wrap any label containing special characters in double quotes:
 
 ```


### PR DESCRIPTION
## Summary
- add explicit rule in `SKILL.md` to use `<br/>` for multi-line flowchart node labels
- document why escaped `\n` should be avoided (it renders as literal text in HTML output)
- add wrong/right example in `references/libraries.md`

## Why
Generated diagrams occasionally contained literal `\n` in node text. This happened because the skill docs discussed `<br/>` support, but did not explicitly forbid `\n` in flowchart labels.

## Scope
Docs-only change. No runtime code changes.
