### PR TITLE
properly output newlines for mermaid charts

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -86,6 +86,8 @@ Vary the choice each time. If the last diagram was dark and technical, make the 
 
 **Mermaid layout direction:** Prefer `flowchart TD` (top-down) over `flowchart LR` (left-to-right) for complex diagrams. LR spreads horizontally and makes labels unreadable when there are many nodes. Use LR only for simple 3-4 node linear flows. See `./references/libraries.md` "Layout Direction: TD vs LR".
 
+**Mermaid label line breaks (flowchart):** For multi-line labels, use `<br/>` inside quoted labels. Do not use `\n` — Mermaid renders it as literal text (for example `User Inputs\nSTDIN`). Example: `A["User Inputs<br/>STDIN"]`. If labels need literal angle brackets, escape them (`&lt;run_id&gt;`).
+
 **Mermaid CSS class collision constraint:** Never define `.node` as a page-level CSS class. Mermaid.js uses `.node` internally on SVG `<g>` elements with `transform: translate(x, y)` for positioning. Page-level `.node` styles (hover transforms, box-shadows) leak into diagrams and break layout. Use the namespaced `.ve-card` class for card components instead. The only safe way to style Mermaid's `.node` is scoped under `.mermaid` (e.g., `.mermaid .node rect`).
 
 **AI-generated illustrations (optional).** If [surf-cli](https://github.com/nicobailon/surf-cli) is available, you can generate images via Gemini and embed them in the page for creative, illustrative, explanatory, educational, or decorative purposes. Check availability with `which surf`. If available:

--- a/references/libraries.md
+++ b/references/libraries.md
@@ -190,6 +190,35 @@ UI -->|Use as Reference| RET
 
 Avoid opaque light fills like `fill:#fefce8` — they render as bright boxes in dark mode.
 
+### Flowchart Label Line Breaks
+
+In flowcharts, Mermaid does not convert `\n` inside labels to visual line breaks — it renders literal `\n` text. Use `<br/>` inside quoted labels:
+
+```
+%% WRONG — renders literal "\n"
+A["User Inputs\nSTDIN + Telegram"]
+
+%% RIGHT — real line break in flowchart labels
+A["User Inputs<br/>STDIN + Telegram"]
+```
+
+If incoming Mermaid text may contain `\n` labels, normalize before `mermaid.initialize()`:
+
+```javascript
+document.querySelectorAll('pre.mermaid').forEach(function(pre) {
+  var src = pre.textContent || '';
+  if (!/^\s*(flowchart|graph)\b/m.test(src)) return;
+  if (!src.includes('\\\\n') && !src.includes('<')) return;
+  pre.textContent = src.replace(/([\[\(\{])"([^"\r\n]*)"([\]\)\}])/g, function(_, open, label, close) {
+    var withBreaks = label.replace(/\\\\n/g, '<br/>');
+    var escapedAngles = withBreaks.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return open + '"' + escapedAngles.replace(/&lt;br\/&gt;/g, '<br/>') + '"' + close;
+  });
+});
+```
+
+If a label includes literal angle brackets (example: `artifacts/<run_id>`), escape them as `&lt;run_id&gt;`.
+
 ### stateDiagram-v2 Label Limitations
 
 State diagram transition labels have a strict parser. Avoid:

--- a/templates/mermaid-flowchart.html
+++ b/templates/mermaid-flowchart.html
@@ -344,6 +344,30 @@
 
   const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
+  function sanitizeFlowchartLabelText(label) {
+    var withBreaks = label.replace(/\\\\n/g, '<br/>');
+    var escapedAngles = withBreaks
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return escapedAngles.replace(/&lt;br\/&gt;/g, '<br/>');
+  }
+
+  function normalizeMermaidLineBreaks() {
+    document.querySelectorAll('pre.mermaid').forEach(function(pre) {
+      var src = pre.textContent || '';
+      var isFlowchart = /^\s*(flowchart|graph)\b/m.test(src);
+      if (!isFlowchart) return;
+      if (src.indexOf('\\\\n') === -1 && src.indexOf('<') === -1) return;
+      // Mermaid flowchart labels use <br/> for line breaks.
+      // Rewrite quoted node labels only; don't touch edge labels or other syntax.
+      pre.textContent = src.replace(/([\[\(\{])"([^"\r\n]*)"([\]\)\}])/g, function(_, open, label, close) {
+        return open + '"' + sanitizeFlowchartLabelText(label) + '"' + close;
+      });
+    });
+  }
+
+  normalizeMermaidLineBreaks();
+
   mermaid.registerLayoutLoaders(elkLayouts);
   mermaid.initialize({
     startOnLoad: true,

--- a/templates/slide-deck.html
+++ b/templates/slide-deck.html
@@ -798,6 +798,31 @@ graph LR
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
 
   const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  function sanitizeFlowchartLabelText(label) {
+    var withBreaks = label.replace(/\\\\n/g, '<br/>');
+    var escapedAngles = withBreaks
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return escapedAngles.replace(/&lt;br\/&gt;/g, '<br/>');
+  }
+
+  function normalizeMermaidLineBreaks() {
+    document.querySelectorAll('pre.mermaid').forEach(function(pre) {
+      var src = pre.textContent || '';
+      var isFlowchart = /^\s*(flowchart|graph)\b/m.test(src);
+      if (!isFlowchart) return;
+      if (src.indexOf('\\\\n') === -1 && src.indexOf('<') === -1) return;
+      // Mermaid flowchart labels use <br/> for line breaks.
+      // Rewrite quoted node labels only; don't touch edge labels or other syntax.
+      pre.textContent = src.replace(/([\[\(\{])"([^"\r\n]*)"([\]\)\}])/g, function(_, open, label, close) {
+        return open + '"' + sanitizeFlowchartLabelText(label) + '"' + close;
+      });
+    });
+  }
+
+  normalizeMermaidLineBreaks();
+
   mermaid.initialize({
     startOnLoad: true,
     theme: 'base',


### PR DESCRIPTION
## Problem

Codex spits out `\n` for mermaid charts -- which are not properly rendered

## Solution

Inform agent how to properly output for mermaid charts -- and add code to sanitize

## Screenshots

main:

<img width="643" height="353" alt="image" src="https://github.com/user-attachments/assets/2022883d-f924-4ed1-a04d-e5c4e075c624" />


here:

<img width="519" height="538" alt="image" src="https://github.com/user-attachments/assets/cf858fd2-38bc-4d4c-8d54-2f1404815d03" />
