### PR TITLE
Make visual-explainer directly installable via `pi install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,16 @@ This skill fixes that. Real typography, dark/light themes, interactive Mermaid d
 
 Note: Claude Code plugins namespace commands as `/visual-explainer:command-name`.
 
-**Pi (manual):**
+**Pi:**
 ```bash
-# Clone the repo
-git clone --depth 1 https://github.com/nicobailon/visual-explainer.git /tmp/visual-explainer
+# Install globally
+pi install git:github.com/nicobailon/visual-explainer
 
-# Install skill
-cp -r /tmp/visual-explainer/plugins/visual-explainer ~/.pi/agent/skills/visual-explainer
-
-# Install prompt templates (slash commands)
-cp /tmp/visual-explainer/plugins/visual-explainer/commands/*.md ~/.pi/agent/prompts/
-
-# Cleanup
-rm -rf /tmp/visual-explainer
+# Or install for just the current project
+pi install -l git:github.com/nicobailon/visual-explainer
 ```
+
+This loads the `visual-explainer` skill plus the prompt templates (`/diff-review`, `/plan-review`, `/generate-web-diagram`, etc.) directly from the git repo.
 
 **OpenAI Codex:**
 ```bash

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "visual-explainer",
   "version": "0.5.1",
   "description": "Agent skill that generates beautiful HTML pages for diagrams, diff reviews, plan reviews, and data tables",
-  "keywords": [
-    "claude-code-plugin",
-    "agent-skill",
-    "pi-package"
-  ],
-  "license": "MIT"
+  "keywords": ["claude-code-plugin", "agent-skill", "pi-package"],
+  "license": "MIT",
+  "pi": {
+    "skills": ["./plugins/visual-explainer"],
+    "prompts": ["./plugins/visual-explainer/commands"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Agent skill that generates beautiful HTML pages for diagrams, diff reviews, plan reviews, and data tables",
   "keywords": [
     "claude-code-plugin",
-    "agent-skill"
+    "agent-skill",
+    "pi-package"
   ],
   "license": "MIT"
 }

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -363,12 +363,12 @@ Share visual explainer pages instantly via Vercel. No account or authentication 
 
 **Usage:**
 ```bash
-bash {{skill_dir}}/scripts/share.sh <html-file>
+bash ./scripts/share.sh <html-file>
 ```
 
 **Example:**
 ```bash
-bash {{skill_dir}}/scripts/share.sh ~/.agent/diagrams/my-diagram.html
+bash ./scripts/share.sh ~/.agent/diagrams/my-diagram.html
 
 # Output:
 # ✓ Shared successfully!

--- a/plugins/visual-explainer/commands/share.md
+++ b/plugins/visual-explainer/commands/share.md
@@ -31,8 +31,10 @@ No Vercel account, Cloudflare account, or API keys needed. The deployment is "cl
 
 ## Script Location
 
+After loading the `visual-explainer` skill, run the script relative to the skill directory:
+
 ```bash
-bash {{skill_dir}}/scripts/share.sh <file>
+bash ./scripts/share.sh <file>
 ```
 
 ## Output


### PR DESCRIPTION
This PR makes the following changes to `visual-explainer`: 

1. Adds a pi manifest to `package.json`, so that pi can recognize it as an extension
2. Replaces {{skill_dir}} with relative-path wording (because Pi does not understand this variable)

I've also updated the README with relevant information and tested that the change works locally.