### PR TITLE
chore: [AI-197] refresh visual explainer docs and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Based on PR #25 by [@peak-flow](https://github.com/peak-flow), with additional m
 ## [0.4.3] - 2026-03-01
 
 ### Mermaid Zoom and Positioning Fixes
+
 - **Fixed zoom clipping**: Replaced `transform: scale()` with CSS `zoom` property. Transform only changes visual appearance — content expanding upward/leftward goes into negative space which can't be scrolled to. Zoom changes actual layout size, so overflow scrolls normally in all directions.
 - **Fixed vertical centering**: Changed `align-items: flex-start` to `align-items: center` so diagrams are centered both horizontally and vertically in their container.
 - **Added initial zoom**: Complex diagrams can start at zoom > 1 (e.g., 1.4x) for better readability while keeping zoom controls functional.
@@ -136,29 +137,35 @@ Based on PR #25 by [@peak-flow](https://github.com/peak-flow), with additional m
 ## [0.4.2] - 2026-03-01
 
 ### Link Styling
+
 - New "Link Styling" section in `css-patterns.md` — never rely on browser default link colors; use accent colors with sufficient contrast
 
 ## [0.4.1] - 2026-03-01
 
 ### Mermaid Layout Direction
+
 - New "Layout Direction: TD vs LR" section in `libraries.md`
 - Prefer `flowchart TD` (top-down) over `flowchart LR` (left-to-right) for complex diagrams
 - LR spreads horizontally and makes labels unreadable with many nodes
 - Rule: use TD for 5+ nodes or any branching; LR only for simple 3-4 node linear flows
 
 ### Documentation
+
 - Simplified README: trimmed Usage section, consolidated Install, added Slide Deck Mode section
 - Added `/generate-visual-plan` to command table
 
 ## [0.4.0] - 2026-02-28
 
 ### New Prompt Template
+
 - `/generate-visual-plan` — generate visual implementation plans for features and extensions. Produces editorial/blueprint-style HTML pages with problem comparison panels, state machine diagrams, code snippets, edge case tables, and implementation notes. Designed for documenting feature specs before implementation.
 
 ### Prose Accent Patterns
+
 Added patterns for use as accent elements within visual pages.
 
 **`css-patterns.md`** — New "Prose Page Elements" section:
+
 - Body text settings (font-size, line-height, max-width for comfortable reading)
 - Lead paragraph patterns (larger size, drop cap variants)
 - Pull quotes (border-left, centered with quotation mark)
@@ -168,18 +175,22 @@ Added patterns for use as accent elements within visual pages.
 - Prose-specific anti-patterns
 
 **`libraries.md`** — New "Typography by Content Voice" section:
+
 - Font recommendations by content type (literary, technical, bold, minimal)
 - Special mention of Literata for screen reading
 
 **`SKILL.md`** — New sections:
+
 - "Prose Accent Elements" — when to use lead paragraphs, pull quotes, callouts
 - "Documentation" — content-to-visual mapping (features→cards, steps→flows, APIs→tables)
 
 ### Overflow Fix: List Markers in Bordered Containers
+
 - `css-patterns.md`: New section "List markers overlapping container borders" with three solutions
 - Rule of thumb: use `list-style-position: inside` or `padding-left: 2em` for lists in bordered containers
 
 ### Mermaid Fixes
+
 - Centering: narrow vertical flowcharts must be centered, not left-aligned
 - Scaling: complex diagrams with 10+ nodes render too small — increase fontSize to 18-20px or use CSS scale transform
 - Special characters: node labels starting with `/`, `\`, `(`, `{` must be quoted to avoid shape syntax conflicts
@@ -187,6 +198,7 @@ Added patterns for use as accent elements within visual pages.
 - New "Node Label Special Characters" section in libraries.md
 
 ### Code Block Patterns
+
 - `css-patterns.md`: New "Code Blocks" section with:
   - Basic pattern with `white-space: pre-wrap` (critical for preserving line breaks)
   - File header pattern for displaying code with filename
@@ -196,6 +208,7 @@ Added patterns for use as accent elements within visual pages.
 ## [0.3.0] - 2026-02-26
 
 ### Anti-Slop Guardrails
+
 - Added explicit "Anti-Patterns (AI Slop)" section to SKILL.md with forbidden patterns
 - Removed "Neon dashboard" and "Gradient mesh" from allowed aesthetics — they always produce generic output
 - Categorized aesthetics as "Constrained" (safer) vs "Flexible" (use with caution)
@@ -208,12 +221,14 @@ Added patterns for use as accent elements within visual pages.
 - Referenced `websocket-implementation-plan.html` as positive example of Blueprint aesthetic
 
 ### Template Fixes
+
 - Replaced violet secondary colors in `mermaid-flowchart.html` with sky blue to match anti-slop guidelines
 - Updated Mermaid themeVariables example in `libraries.md` to use teal/slate palette instead of violet
 
 ## [0.2.0] - 2026-02-25
 
 ### Slide Deck Mode
+
 - New output format: magazine-quality slide deck presentations as self-contained HTML files
 - 10 slide types: Title, Section Divider, Content, Split, Diagram, Dashboard, Table, Code, Quote, Full-Bleed
 - SlideEngine JS: keyboard/touch/wheel navigation, progress bar, nav dots, slide counter, keyboard hints with auto-fade
@@ -231,6 +246,7 @@ Added patterns for use as accent elements within visual pages.
 - Fix quote slides with long text (proportional font-size reduction)
 
 ### Files
+
 - `references/slide-patterns.md` — slide engine CSS, all 10 type layouts, transitions, nav chrome, content density limits, presets
 - `templates/slide-deck.html` — reference template demonstrating all 10 types in Midnight Editorial preset
 - `prompts/generate-slides.md` — slash command for generating slide decks
@@ -262,6 +278,7 @@ Added patterns for use as accent elements within visual pages.
 Initial release.
 
 ### Skill
+
 - Core workflow: Think (pick aesthetic) → Structure (read template) → Style (apply design) → Deliver (write + open)
 - 11 diagram types with rendering approach routing (Mermaid, CSS Grid, HTML tables, Chart.js)
 - 9 aesthetic directions (monochrome terminal, editorial, blueprint, neon, paper/ink, sketch, IDE-inspired, data-dense, gradient mesh)
@@ -273,16 +290,19 @@ Initial release.
 - Quality checks: squint test, swap test, overflow protection, zoom controls verification
 
 ### References
+
 - `css-patterns.md` — theme setup, depth tiers, node cards, grid layouts, data tables, status badges, KPI cards, before/after panels, connectors, animations (fadeUp, fadeScale, drawIn, countUp), collapsible sections, overflow protection, generated image containers
 - `libraries.md` — Mermaid (CDN, ELK, deep theming, hand-drawn mode, CSS overrides, diagram examples), Chart.js, anime.js, Google Fonts with 13 font pairings
 - `responsive-nav.md` — sticky sidebar TOC on desktop, horizontal scrollable bar on mobile, scroll spy
 
 ### Templates
+
 - `architecture.html` — CSS Grid card layout, terracotta/sage palette, depth tiers, flow arrows, pipeline with parallel branches
 - `mermaid-flowchart.html` — Mermaid flowchart with ELK + handDrawn mode, teal/cyan palette, zoom controls
 - `data-table.html` — HTML table with KPI cards, status badges, collapsible details, rose/cranberry palette
 
 ### Prompt Templates
+
 - `/generate-web-diagram` — generate a diagram for any topic
 - `/diff-review` — visual diff review with architecture comparison, KPI dashboard, code review, decision log
 - `/plan-review` — plan vs. codebase with current/planned architecture, risk assessment, understanding gaps

--- a/plugins/visual-explainer/commands/fact-check.md
+++ b/plugins/visual-explainer/commands/fact-check.md
@@ -1,20 +1,24 @@
 ---
 description: Verify the factual accuracy of a document against the actual codebase, correct inaccuracies in place
 ---
+
 Load the visual-explainer skill, then verify the factual accuracy of a document that makes claims about a codebase. Read the file, extract every verifiable claim, check each against the actual code and git history, correct inaccuracies in place, and add a verification summary.
 
 For HTML files: read `./references/css-patterns.md` to match the existing page's styling when inserting the verification summary.
 
 **Target file** — determine what to verify from `$1`:
+
 - Explicit path: verify that specific file (`.html`, `.md`, or any text document)
 - No argument: verify the most recently modified `.html` file in `~/.agent/diagrams/` (`ls -t ~/.agent/diagrams/*.html | head -1`)
 
 Auto-detect the document type and adjust the verification strategy:
+
 - **HTML review pages** (diff-review, plan-review, project-recap): detect from page content, verify against the git ref or plan file the review was based on
 - **Plan/spec documents** (markdown): verify file references, function/type names, behavior descriptions, and architecture claims against the current codebase
 - **Any other document**: extract and verify whatever factual claims about code it contains
 
 **Phase 1: Extract claims.** Read the file. Extract every verifiable factual claim:
+
 - **Quantitative**: line counts, file counts, function counts, module counts, test counts, any numeric metrics
 - **Naming**: function names, type names, module names, file paths referenced in the document
 - **Behavioral**: descriptions of what code does, how things work, before/after comparisons
@@ -24,6 +28,7 @@ Auto-detect the document type and adjust the verification strategy:
 Skip subjective analysis (opinions, design judgments, readability assessments) — these aren't verifiable facts.
 
 **Phase 2: Verify against source.** For each extracted claim, go to the source:
+
 - Re-read every file referenced in the document — check function signatures, type definitions, behavior descriptions against the actual code
 - For claims about git history: re-run git commands (`git diff --stat`, `git log`, `git diff --name-status`, etc.) and compare output against the document's numbers
 - For diff-reviews: read both the ref version (`git show <ref>:file`) and working tree version to verify before/after claims aren't swapped or fabricated
@@ -31,11 +36,13 @@ Skip subjective analysis (opinions, design judgments, readability assessments) �
 - For project-recaps: re-run `git log` commands to verify activity narrative and timeline
 
 Classify each claim:
+
 - **Confirmed**: claim matches the code/output exactly
 - **Corrected**: claim was inaccurate — note what was wrong and what the correct value is
 - **Unverifiable**: claim can't be checked (e.g., references a file that doesn't exist, or a behavior that requires runtime testing)
 
 **Phase 3: Correct in place.** Edit the file directly using surgical text replacements:
+
 - Fix incorrect numbers, function names, file paths, behavior descriptions
 - Fix before/after swaps (a common error class in review pages)
 - If a section is fundamentally wrong (not just a detail error), rewrite that section's content while preserving the surrounding structure
@@ -43,10 +50,12 @@ Classify each claim:
 - For markdown: preserve heading structure, formatting, and document organization
 
 **Phase 4: Add verification summary.**
+
 - **HTML files**: insert a verification section as a banner at the top or final section, matching the page's existing styling. Use a subtle card with muted colors.
 - **Markdown files**: append a `## Verification Summary` section at the end of the document.
 
 Include in the summary:
+
 - Total claims checked
 - Claims confirmed (with count)
 - Corrections made (with brief list of what was fixed: "Changed `processCleanup` to `runCleanup` to match actual function name in `worker.ts:45`")

--- a/plugins/visual-explainer/commands/generate-slides.md
+++ b/plugins/visual-explainer/commands/generate-slides.md
@@ -1,6 +1,7 @@
 ---
 description: Generate a stunning magazine-quality slide deck as a self-contained HTML page
 ---
+
 Load the visual-explainer skill, then generate a slide deck for: $@
 
 Follow the visual-explainer skill workflow. Read the reference template at `./templates/slide-deck.html` and slide patterns at `./references/slide-patterns.md` before generating. Also read `./references/css-patterns.md` for shared patterns (Mermaid zoom controls, depth tiers, overflow protection) and `./references/libraries.md` for Mermaid theming, Chart.js, and font pairings.

--- a/plugins/visual-explainer/commands/generate-web-diagram.md
+++ b/plugins/visual-explainer/commands/generate-web-diagram.md
@@ -1,6 +1,7 @@
 ---
 description: Generate a beautiful standalone HTML diagram and open it in the browser
 ---
+
 Load the visual-explainer skill, then generate an HTML diagram for: $@
 
 Follow the visual-explainer skill workflow. Read the reference template and CSS patterns before generating. Pick a distinctive aesthetic that fits the content — vary fonts, palette, and layout style from previous diagrams.

--- a/plugins/visual-explainer/references/libraries.md
+++ b/plugins/visual-explainer/references/libraries.md
@@ -9,22 +9,24 @@ Use for flowcharts, sequence diagrams, ER diagrams, state machines, mind maps, c
 Do NOT use for dashboards — CSS Grid card layouts with Chart.js look better for those. Data tables use `<table>` elements.
 
 **CDN:**
+
 ```html
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
 
-  mermaid.initialize({ startOnLoad: true, /* ... */ });
+  mermaid.initialize({ startOnLoad: true /* ... */ });
 </script>
 ```
 
 **With ELK layout** (required for `layout: 'elk'` — it's a separate package, not bundled in core):
+
 ```html
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-  import elkLayouts from 'https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk/dist/mermaid-layout-elk.esm.min.mjs';
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk/dist/mermaid-layout-elk.esm.min.mjs";
 
   mermaid.registerLayoutLoaders(elkLayouts);
-  mermaid.initialize({ startOnLoad: true, layout: 'elk', /* ... */ });
+  mermaid.initialize({ startOnLoad: true, layout: "elk" /* ... */ });
 </script>
 ```
 
@@ -36,34 +38,34 @@ Always use `theme: 'base'` — it's the only theme where all `themeVariables` ar
 
 ```html
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
 
-  const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'base',
-    look: 'classic',
+    theme: "base",
+    look: "classic",
     themeVariables: {
       // Background and surfaces — teal/slate palette (not violet/indigo!)
-      primaryColor: isDark ? '#134e4a' : '#ccfbf1',
-      primaryBorderColor: isDark ? '#14b8a6' : '#0d9488',
-      primaryTextColor: isDark ? '#f0fdfa' : '#134e4a',
-      secondaryColor: isDark ? '#1e293b' : '#f0fdf4',
-      secondaryBorderColor: isDark ? '#059669' : '#16a34a',
-      secondaryTextColor: isDark ? '#f1f5f9' : '#1e293b',
-      tertiaryColor: isDark ? '#27201a' : '#fef3c7',
-      tertiaryBorderColor: isDark ? '#d97706' : '#f59e0b',
-      tertiaryTextColor: isDark ? '#fef3c7' : '#27201a',
+      primaryColor: isDark ? "#134e4a" : "#ccfbf1",
+      primaryBorderColor: isDark ? "#14b8a6" : "#0d9488",
+      primaryTextColor: isDark ? "#f0fdfa" : "#134e4a",
+      secondaryColor: isDark ? "#1e293b" : "#f0fdf4",
+      secondaryBorderColor: isDark ? "#059669" : "#16a34a",
+      secondaryTextColor: isDark ? "#f1f5f9" : "#1e293b",
+      tertiaryColor: isDark ? "#27201a" : "#fef3c7",
+      tertiaryBorderColor: isDark ? "#d97706" : "#f59e0b",
+      tertiaryTextColor: isDark ? "#fef3c7" : "#27201a",
       // Lines and edges
-      lineColor: isDark ? '#64748b' : '#94a3b8',
+      lineColor: isDark ? "#64748b" : "#94a3b8",
       // Text
-      fontSize: '16px',
-      fontFamily: 'var(--font-body)',
+      fontSize: "16px",
+      fontFamily: "var(--font-body)",
       // Notes and labels
-      noteBkgColor: isDark ? '#1e293b' : '#fefce8',
-      noteTextColor: isDark ? '#f1f5f9' : '#1e293b',
-      noteBorderColor: isDark ? '#fbbf24' : '#d97706',
-    }
+      noteBkgColor: isDark ? "#1e293b" : "#fefce8",
+      noteTextColor: isDark ? "#f1f5f9" : "#1e293b",
+      noteBorderColor: isDark ? "#fbbf24" : "#d97706",
+    },
   });
 </script>
 ```
@@ -90,9 +92,16 @@ Mermaid renders SVG. Override its classes for pixel-perfect control that `themeV
    but any classDef that sets color: will hardcode a single value that
    breaks in the opposite color scheme. Fix: never set color: in classDef,
    and always include these CSS overrides. */
-.mermaid .nodeLabel { color: var(--text) !important; }
-.mermaid .edgeLabel { color: var(--text-dim) !important; background-color: var(--bg) !important; }
-.mermaid .edgeLabel rect { fill: var(--bg) !important; }
+.mermaid .nodeLabel {
+  color: var(--text) !important;
+}
+.mermaid .edgeLabel {
+  color: var(--text-dim) !important;
+  background-color: var(--bg) !important;
+}
+.mermaid .edgeLabel rect {
+  fill: var(--bg) !important;
+}
 
 /* Node shapes */
 .mermaid .node rect,
@@ -158,6 +167,7 @@ classDef muted fill:#7c6f6411,stroke:#7c6f6444,stroke-width:1px
 Mermaid uses certain characters for shape syntax. Node labels containing these characters cause syntax errors unless quoted.
 
 **Shape characters to watch:**
+
 - `[/text/]` — parallelogram
 - `[\text\]` — trapezoid (alt)
 - `[/text\]` — trapezoid
@@ -193,6 +203,7 @@ Avoid opaque light fills like `fill:#fefce8` — they render as bright boxes in 
 ### stateDiagram-v2 Label Limitations
 
 State diagram transition labels have a strict parser. Avoid:
+
 - `<br/>` — only works in flowcharts; causes a parse error in state diagrams
 - Parentheses in labels — `cancel()` can confuse the parser
 - Multiple colons — the first `:` is the label delimiter; extra colons in the label text may break parsing
@@ -240,12 +251,12 @@ Auth --> API
 
 **Arrow styles for semantic meaning:**
 
-| Arrow | Meaning | Use for |
-|-------|---------|---------|
-| `-->` | Solid | Primary flow |
-| `-.->` | Dotted | Optional, async, or fallback paths |
-| `==>` | Thick | Critical or highlighted path |
-| `--x` | Cross | Rejected or blocked |
+| Arrow          | Meaning | Use for                              |
+| -------------- | ------- | ------------------------------------ |
+| `-->`          | Solid   | Primary flow                         |
+| `-.->`         | Dotted  | Optional, async, or fallback paths   |
+| `==>`          | Thick   | Critical or highlighted path         |
+| `--x`          | Cross   | Rejected or blocked                  |
 | `-->\|label\|` | Labeled | Decision branches, data descriptions |
 
 **Escape pipes in labels.** If a label contains a literal `|`, use `#124;` (HTML entity) or rephrase to avoid it — pipes delimit edge labels in flowcharts.
@@ -272,10 +283,10 @@ B->>S: POST /submit with selected indices
 
 **When to use each:**
 
-| Direction | Use when | Avoid when |
-|-----------|----------|------------|
-| `TD` (top-down) | Complex diagrams, 5+ nodes, hierarchies, architecture | Simple A→B→C linear flows |
-| `LR` (left-to-right) | Simple linear flows, 3-4 nodes, pipelines | Complex graphs, many branches |
+| Direction            | Use when                                              | Avoid when                    |
+| -------------------- | ----------------------------------------------------- | ----------------------------- |
+| `TD` (top-down)      | Complex diagrams, 5+ nodes, hierarchies, architecture | Simple A→B→C linear flows     |
+| `LR` (left-to-right) | Simple linear flows, 3-4 nodes, pipelines             | Complex graphs, many branches |
 
 **Rule of thumb:** If the diagram has more than one row of nodes or any branching, use `TD`. The extra vertical space makes labels readable.
 
@@ -284,7 +295,7 @@ B->>S: POST /submit with selected indices
 flowchart LR
   A --> B --> C --> D --> E
   A --> F --> G --> H
-  
+
 %% RIGHT — TD uses vertical space, labels stay readable
 flowchart TD
   A --> B --> C --> D --> E
@@ -294,6 +305,7 @@ flowchart TD
 ### Diagram Type Examples
 
 **Flowchart with decisions:**
+
 ```html
 <pre class="mermaid">
 graph TD
@@ -309,6 +321,7 @@ graph TD
 ```
 
 **Sequence diagram:**
+
 ```html
 <pre class="mermaid">
 sequenceDiagram
@@ -327,6 +340,7 @@ sequenceDiagram
 ```
 
 **ER diagram:**
+
 ```html
 <pre class="mermaid">
 erDiagram
@@ -341,6 +355,7 @@ erDiagram
 ```
 
 **State diagram:**
+
 ```html
 <pre class="mermaid">
 stateDiagram-v2
@@ -355,6 +370,7 @@ stateDiagram-v2
 ```
 
 **Mind map:**
+
 ```html
 <pre class="mermaid">
 mindmap
@@ -438,7 +454,7 @@ Quick-reference for choosing the right Mermaid syntax:
 Mermaid initializes once — it can't reactively switch themes. Read the preference at load time inside your `<script type="module">`:
 
 ```javascript
-const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
 // Use isDark to pick light or dark values in themeVariables
 ```
 
@@ -454,24 +470,27 @@ Use for bar charts, line charts, pie/doughnut charts, radar charts, and other da
 <canvas id="myChart" width="600" height="300"></canvas>
 
 <script>
-  const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const textColor = isDark ? '#8b949e' : '#6b7280';
-  const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
-  const fontFamily = getComputedStyle(document.documentElement)
-    .getPropertyValue('--font-body').trim() || 'system-ui, sans-serif';
+  const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const textColor = isDark ? "#8b949e" : "#6b7280";
+  const gridColor = isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)";
+  const fontFamily =
+    getComputedStyle(document.documentElement).getPropertyValue("--font-body").trim() ||
+    "system-ui, sans-serif";
 
-  new Chart(document.getElementById('myChart'), {
-    type: 'bar',
+  new Chart(document.getElementById("myChart"), {
+    type: "bar",
     data: {
-      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
-      datasets: [{
-        label: 'Feedback Items',
-        data: [45, 62, 78, 91, 120],
-        backgroundColor: isDark ? 'rgba(129, 140, 248, 0.6)' : 'rgba(79, 70, 229, 0.6)',
-        borderColor: isDark ? '#818cf8' : '#4f46e5',
-        borderWidth: 1,
-        borderRadius: 4,
-      }]
+      labels: ["Jan", "Feb", "Mar", "Apr", "May"],
+      datasets: [
+        {
+          label: "Feedback Items",
+          data: [45, 62, 78, 91, 120],
+          backgroundColor: isDark ? "rgba(129, 140, 248, 0.6)" : "rgba(79, 70, 229, 0.6)",
+          borderColor: isDark ? "#818cf8" : "#4f46e5",
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+      ],
     },
     options: {
       responsive: true,
@@ -479,15 +498,22 @@ Use for bar charts, line charts, pie/doughnut charts, radar charts, and other da
         legend: { labels: { color: textColor, font: { family: fontFamily } } },
       },
       scales: {
-        x: { ticks: { color: textColor, font: { family: fontFamily } }, grid: { color: gridColor } },
-        y: { ticks: { color: textColor, font: { family: fontFamily } }, grid: { color: gridColor } },
-      }
-    }
+        x: {
+          ticks: { color: textColor, font: { family: fontFamily } },
+          grid: { color: gridColor },
+        },
+        y: {
+          ticks: { color: textColor, font: { family: fontFamily } },
+          grid: { color: gridColor },
+        },
+      },
+    },
   });
 </script>
 ```
 
 Wrap the canvas in a styled container:
+
 ```css
 .chart-container {
   background: var(--surface);
@@ -510,35 +536,37 @@ Use when a diagram has 10+ elements and you want a choreographed entrance sequen
 <script src="https://cdn.jsdelivr.net/npm/animejs@3.2.2/lib/anime.min.js"></script>
 
 <script>
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   if (!prefersReduced) {
     anime({
-      targets: '.ve-card',
+      targets: ".ve-card",
       opacity: [0, 1],
       translateY: [20, 0],
       delay: anime.stagger(80, { start: 200 }),
-      easing: 'easeOutCubic',
+      easing: "easeOutCubic",
       duration: 500,
     });
 
     anime({
-      targets: '.connector path',
+      targets: ".connector path",
       strokeDashoffset: [anime.setDashoffset, 0],
-      easing: 'easeInOutCubic',
+      easing: "easeInOutCubic",
       duration: 800,
       delay: anime.stagger(150, { start: 600 }),
     });
 
-    document.querySelectorAll('[data-count]').forEach(el => {
+    document.querySelectorAll("[data-count]").forEach((el) => {
       anime({
         targets: { val: 0 },
         val: parseInt(el.dataset.count),
         round: 1,
         duration: 1200,
         delay: 400,
-        easing: 'easeOutExpo',
-        update: (anim) => { el.textContent = anim.animations[0].currentValue; }
+        easing: "easeOutExpo",
+        update: (anim) => {
+          el.textContent = anim.animations[0].currentValue;
+        },
       });
     });
   }
@@ -546,11 +574,16 @@ Use when a diagram has 10+ elements and you want a choreographed entrance sequen
 ```
 
 When using anime.js, set initial opacity to 0 in CSS so elements don't flash before the animation:
+
 ```css
-.ve-card { opacity: 0; }
+.ve-card {
+  opacity: 0;
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .ve-card { opacity: 1 !important; }
+  .ve-card {
+    opacity: 1 !important;
+  }
 }
 ```
 
@@ -559,42 +592,47 @@ When using anime.js, set initial opacity to 0 in CSS so elements don't flash bef
 Always load with `display=swap` for fast rendering. Pick a distinctive pairing — body + mono at minimum, optionally a display font for the title.
 
 **FORBIDDEN as `--font-body` (AI slop signals):**
+
 - Inter — the single most overused AI default font
 - Roboto — generic Android/Google default
 - Arial, Helvetica — system defaults with no character
 - system-ui alone without a named font — signals zero design intent
 
 ```html
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Outfit:wght@400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
 ```
 
 Define as CSS variables for easy reference:
+
 ```css
 :root {
-  --font-body: 'Outfit', system-ui, sans-serif;
-  --font-mono: 'Space Mono', 'SF Mono', Consolas, monospace;
+  --font-body: "Outfit", system-ui, sans-serif;
+  --font-mono: "Space Mono", "SF Mono", Consolas, monospace;
 }
 ```
 
 **Font pairings** (rotate — never use the same pairing twice in a row):
 
-| Body / Headings | Mono / Labels | Feel | Use for |
-|---|---|---|---|
-| DM Sans | Fira Code | Friendly, developer | Blueprint, technical docs |
-| Instrument Serif | JetBrains Mono | Editorial, refined | Plan reviews, decision logs |
-| IBM Plex Sans | IBM Plex Mono | Reliable, readable | Architecture diagrams |
-| Bricolage Grotesque | Fragment Mono | Bold, characterful | Data tables, dashboards |
-| Plus Jakarta Sans | Azeret Mono | Rounded, approachable | Status reports, audits |
-| Outfit | Space Mono | Clean geometric, modern | Flowcharts, pipelines |
-| Sora | IBM Plex Mono | Technical, precise | ER diagrams, schemas |
-| Crimson Pro | Noto Sans Mono | Scholarly, serious | RFC reviews, specs |
-| Fraunces | Source Code Pro | Warm, distinctive | Project recaps |
-| Geist | Geist Mono | Vercel-inspired, sharp | Modern API docs |
-| Red Hat Display | Red Hat Mono | Cohesive family | System overviews |
-| Libre Franklin | Inconsolata | Classic, reliable | Data-dense tables |
-| Playfair Display | Roboto Mono | Elegant contrast | Executive summaries |
+| Body / Headings     | Mono / Labels   | Feel                    | Use for                     |
+| ------------------- | --------------- | ----------------------- | --------------------------- |
+| DM Sans             | Fira Code       | Friendly, developer     | Blueprint, technical docs   |
+| Instrument Serif    | JetBrains Mono  | Editorial, refined      | Plan reviews, decision logs |
+| IBM Plex Sans       | IBM Plex Mono   | Reliable, readable      | Architecture diagrams       |
+| Bricolage Grotesque | Fragment Mono   | Bold, characterful      | Data tables, dashboards     |
+| Plus Jakarta Sans   | Azeret Mono     | Rounded, approachable   | Status reports, audits      |
+| Outfit              | Space Mono      | Clean geometric, modern | Flowcharts, pipelines       |
+| Sora                | IBM Plex Mono   | Technical, precise      | ER diagrams, schemas        |
+| Crimson Pro         | Noto Sans Mono  | Scholarly, serious      | RFC reviews, specs          |
+| Fraunces            | Source Code Pro | Warm, distinctive       | Project recaps              |
+| Geist               | Geist Mono      | Vercel-inspired, sharp  | Modern API docs             |
+| Red Hat Display     | Red Hat Mono    | Cohesive family         | System overviews            |
+| Libre Franklin      | Inconsolata     | Classic, reliable       | Data-dense tables           |
+| Playfair Display    | Roboto Mono     | Elegant contrast        | Executive summaries         |
 
 The first 5 pairings are recommended for most use cases. Vary across consecutive diagrams.
 
@@ -602,11 +640,11 @@ The first 5 pairings are recommended for most use cases. Vary across consecutive
 
 For prose-heavy pages (documentation, articles, essays), match typography to the content's voice:
 
-| Voice | Fonts | Best For |
-|-------|-------|----------|
-| **Literary / Thoughtful** | Literata, Lora, Newsreader, Merriweather | Essays, personal posts, long-form articles |
-| **Technical / Precise** | IBM Plex Sans + Mono, Geist + Geist Mono, Source family | Documentation, READMEs, API references |
-| **Bold / Contemporary** | Bricolage Grotesque, Space Grotesk, DM Sans | Product pages, feature announcements |
-| **Minimal / Focused** | Source Serif 4 + Source Sans 3, Karla + Inconsolata | Tutorials, how-tos, focused reading |
+| Voice                     | Fonts                                                   | Best For                                   |
+| ------------------------- | ------------------------------------------------------- | ------------------------------------------ |
+| **Literary / Thoughtful** | Literata, Lora, Newsreader, Merriweather                | Essays, personal posts, long-form articles |
+| **Technical / Precise**   | IBM Plex Sans + Mono, Geist + Geist Mono, Source family | Documentation, READMEs, API references     |
+| **Bold / Contemporary**   | Bricolage Grotesque, Space Grotesk, DM Sans             | Product pages, feature announcements       |
+| **Minimal / Focused**     | Source Serif 4 + Source Sans 3, Karla + Inconsolata     | Tutorials, how-tos, focused reading        |
 
 **Literata** deserves special mention — it has optical sizing designed specifically for screen reading. Google's answer to Georgia, but modernized.

--- a/plugins/visual-explainer/references/responsive-nav.md
+++ b/plugins/visual-explainer/references/responsive-nav.md
@@ -8,31 +8,32 @@ The page uses a two-column CSS Grid: sidebar (TOC) + main content. On mobile it 
 
 ```html
 <body>
-<div class="wrap">
+  <div class="wrap">
+    <nav class="toc" id="toc">
+      <div class="toc-title">Contents</div>
+      <a href="#s1">1. First Section</a>
+      <a href="#s2">2. Second Section</a>
+      <!-- one link per section -->
+    </nav>
 
-  <nav class="toc" id="toc">
-    <div class="toc-title">Contents</div>
-    <a href="#s1">1. First Section</a>
-    <a href="#s2">2. Second Section</a>
-    <!-- one link per section -->
-  </nav>
+    <div class="main">
+      <h1>Page Title</h1>
+      <p class="subtitle">Subtitle text</p>
 
-  <div class="main">
-    <h1>Page Title</h1>
-    <p class="subtitle">Subtitle text</p>
+      <div id="s1" class="sec-head ...">1 — First Section</div>
+      <!-- section content -->
 
-    <div id="s1" class="sec-head ...">1 — First Section</div>
-    <!-- section content -->
-
-    <div id="s2" class="sec-head ...">2 — Second Section</div>
-    <!-- section content -->
-  </div><!-- /main -->
-
-</div><!-- /wrap -->
+      <div id="s2" class="sec-head ...">2 — Second Section</div>
+      <!-- section content -->
+    </div>
+    <!-- /main -->
+  </div>
+  <!-- /wrap -->
 </body>
 ```
 
 Key structural rules:
+
 - `<nav class="toc">` is the **first child** of `.wrap`
 - All page content goes inside `<div class="main">`
 - Every section heading gets an `id="s1"`, `id="s2"`, etc.
@@ -51,7 +52,9 @@ Key structural rules:
   grid-template-columns: 170px 1fr;
   gap: 0 40px;
 }
-.main { min-width: 0; }
+.main {
+  min-width: 0;
+}
 ```
 
 ### TOC — Desktop (sticky sidebar)
@@ -66,8 +69,13 @@ Key structural rules:
   max-height: calc(100dvh - 48px);
   overflow-y: auto;
 }
-.toc::-webkit-scrollbar { width: 3px; }
-.toc::-webkit-scrollbar-thumb { background: var(--surface-elevated); border-radius: 2px; }
+.toc::-webkit-scrollbar {
+  width: 3px;
+}
+.toc::-webkit-scrollbar-thumb {
+  background: var(--surface-elevated);
+  border-radius: 2px;
+}
 
 .toc-title {
   font-family: var(--font-mono);
@@ -93,8 +101,14 @@ Key structural rules:
   line-height: 1.4;
   margin-bottom: 1px;
 }
-.toc a:hover { color: var(--text); background: var(--surface2); }
-.toc a.active { color: var(--text); border-left-color: var(--accent); }
+.toc a:hover {
+  color: var(--text);
+  background: var(--surface2);
+}
+.toc a.active {
+  color: var(--text);
+  border-left-color: var(--accent);
+}
 ```
 
 Replace `var(--accent)` with your page's primary accent color variable (e.g., `var(--orange)`, `var(--blue)`).
@@ -103,8 +117,13 @@ Replace `var(--accent)` with your page's primary accent color variable (e.g., `v
 
 ```css
 @media (max-width: 1000px) {
-  .wrap { grid-template-columns: 1fr; padding-top: 0; }
-  body { padding-top: 0; }
+  .wrap {
+    grid-template-columns: 1fr;
+    padding-top: 0;
+  }
+  body {
+    padding-top: 0;
+  }
 
   .toc {
     position: sticky;
@@ -124,8 +143,12 @@ Replace `var(--accent)` with your page's primary accent color variable (e.g., `v
     padding-right: 40px;
     grid-row: auto;
   }
-  .toc::-webkit-scrollbar { display: none; }
-  .toc-title { display: none; }
+  .toc::-webkit-scrollbar {
+    display: none;
+  }
+  .toc-title {
+    display: none;
+  }
 
   .toc a {
     white-space: nowrap;
@@ -142,10 +165,14 @@ Replace `var(--accent)` with your page's primary accent color variable (e.g., `v
     background: var(--surface);
   }
 
-  .main { padding-top: 20px; }
+  .main {
+    padding-top: 20px;
+  }
 
   /* Offset scroll target so headings clear the sticky bar */
-  .sec-head { scroll-margin-top: 52px; }
+  .sec-head {
+    scroll-margin-top: 52px;
+  }
 }
 ```
 
@@ -157,49 +184,54 @@ Place before `</body>`, after any Mermaid init:
 
 ```html
 <script>
-(function() {
-  const toc = document.getElementById('toc');
-  const links = toc.querySelectorAll('a');
-  const sections = [];
+  (function () {
+    const toc = document.getElementById("toc");
+    const links = toc.querySelectorAll("a");
+    const sections = [];
 
-  links.forEach(link => {
-    const id = link.getAttribute('href').slice(1);
-    const el = document.getElementById(id);
-    if (el) sections.push({ id, el, link });
-  });
-
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        links.forEach(l => l.classList.remove('active'));
-        const match = sections.find(s => s.el === entry.target);
-        if (match) {
-          match.link.classList.add('active');
-          // On mobile, auto-scroll the active tab into view
-          if (window.innerWidth <= 1000) {
-            match.link.scrollIntoView({
-              behavior: 'smooth', block: 'nearest', inline: 'center'
-            });
-          }
-        }
-      }
-    });
-  }, { rootMargin: '-10% 0px -80% 0px' });
-
-  sections.forEach(s => observer.observe(s.el));
-
-  links.forEach(link => {
-    link.addEventListener('click', e => {
-      e.preventDefault();
-      const id = link.getAttribute('href').slice(1);
+    links.forEach((link) => {
+      const id = link.getAttribute("href").slice(1);
       const el = document.getElementById(id);
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        history.replaceState(null, '', '#' + id);
-      }
+      if (el) sections.push({ id, el, link });
     });
-  });
-})();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            links.forEach((l) => l.classList.remove("active"));
+            const match = sections.find((s) => s.el === entry.target);
+            if (match) {
+              match.link.classList.add("active");
+              // On mobile, auto-scroll the active tab into view
+              if (window.innerWidth <= 1000) {
+                match.link.scrollIntoView({
+                  behavior: "smooth",
+                  block: "nearest",
+                  inline: "center",
+                });
+              }
+            }
+          }
+        });
+      },
+      { rootMargin: "-10% 0px -80% 0px" },
+    );
+
+    sections.forEach((s) => observer.observe(s.el));
+
+    links.forEach((link) => {
+      link.addEventListener("click", (e) => {
+        e.preventDefault();
+        const id = link.getAttribute("href").slice(1);
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+          history.replaceState(null, "", "#" + id);
+        }
+      });
+    });
+  })();
 </script>
 ```
 

--- a/plugins/visual-explainer/references/slide-patterns.md
+++ b/plugins/visual-explainer/references/slide-patterns.md
@@ -13,6 +13,7 @@ When converting a plan, spec, review, or any structured document into slides, fo
 **Step 1 — Inventory the source.** Read the entire source document and enumerate every section, subsection, card, table row, decision, specification, collapsible detail, and footnote. Count them. A plan with 7 sections, 6 decision cards, a 7-row file table, 4 presets, 6 technique guides, and an engine spec with 3 sub-specs and 2 collapsibles is ~25 distinct content items that all need slide real estate.
 
 **Step 2 — Map source to slides.** Assign each inventory item to one or more slides. Every item must appear somewhere. Rules:
+
 - If a section has 6 decisions, all 6 need slides — not the 2 that fit on one split slide.
 - If a table has 7 rows, all 7 rows show up.
 - Collapsible/expandable details in the source are not optional in the deck — they become their own slides.
@@ -33,12 +34,12 @@ The deck is a scroll-snap container. Each slide is exactly one viewport tall.
 
 ```html
 <body>
-<div class="deck">
-  <section class="slide slide--title"> ... </section>
-  <section class="slide slide--content"> ... </section>
-  <section class="slide slide--diagram"> ... </section>
-  <!-- one <section> per slide -->
-</div>
+  <div class="deck">
+    <section class="slide slide--title">...</section>
+    <section class="slide slide--content">...</section>
+    <section class="slide slide--diagram">...</section>
+    <!-- one <section> per slide -->
+  </div>
 </body>
 ```
 
@@ -110,15 +111,15 @@ Slide typography is 2–3× larger than scrollable pages. Page-sized text on a v
 }
 ```
 
-| Element | Size range | Notes |
-|---------|-----------|-------|
-| Display (title slides) | 48–120px | `10vw` preferred, weight 800 |
-| Section numbers | 100–240px | Ultra-light (weight 200), decorative |
-| Headings | 28–48px | `5vw` preferred, weight 700 |
-| Body / bullets | 16–24px | `2.2vw` preferred, 1.6 line-height |
-| Code blocks | 14–18px | `1.8vw` preferred, mono |
-| Quotes | 24–48px | `4vw` preferred, serif italic |
-| Labels / captions | 10–14px | Mono, uppercase, dimmed |
+| Element                | Size range | Notes                                |
+| ---------------------- | ---------- | ------------------------------------ |
+| Display (title slides) | 48–120px   | `10vw` preferred, weight 800         |
+| Section numbers        | 100–240px  | Ultra-light (weight 200), decorative |
+| Headings               | 28–48px    | `5vw` preferred, weight 700          |
+| Body / bullets         | 16–24px    | `2.2vw` preferred, 1.6 line-height   |
+| Code blocks            | 14–18px    | `1.8vw` preferred, mono              |
+| Quotes                 | 24–48px    | `4vw` preferred, serif italic        |
+| Labels / captions      | 10–14px    | Mono, uppercase, dimmed              |
 
 ## Cinematic Transitions
 
@@ -154,12 +155,24 @@ IntersectionObserver adds `.visible` when a slide enters the viewport. Slides an
 }
 
 /* Stagger delays — up to 6 children per slide */
-.slide.visible .reveal:nth-child(1) { transition-delay: 0.1s; }
-.slide.visible .reveal:nth-child(2) { transition-delay: 0.2s; }
-.slide.visible .reveal:nth-child(3) { transition-delay: 0.3s; }
-.slide.visible .reveal:nth-child(4) { transition-delay: 0.4s; }
-.slide.visible .reveal:nth-child(5) { transition-delay: 0.5s; }
-.slide.visible .reveal:nth-child(6) { transition-delay: 0.6s; }
+.slide.visible .reveal:nth-child(1) {
+  transition-delay: 0.1s;
+}
+.slide.visible .reveal:nth-child(2) {
+  transition-delay: 0.2s;
+}
+.slide.visible .reveal:nth-child(3) {
+  transition-delay: 0.3s;
+}
+.slide.visible .reveal:nth-child(4) {
+  transition-delay: 0.4s;
+}
+.slide.visible .reveal:nth-child(5) {
+  transition-delay: 0.5s;
+}
+.slide.visible .reveal:nth-child(6) {
+  transition-delay: 0.6s;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .slide,
@@ -213,7 +226,9 @@ All navigation is `position: fixed` with high z-index, layered above slides. Sty
   border: none;
   padding: 0;
   cursor: pointer;
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .deck-dot:hover {
@@ -296,8 +311,8 @@ Add once at the end of the page. Handles navigation, chrome updates, and scroll-
 ```javascript
 class SlideEngine {
   constructor() {
-    this.deck = document.querySelector('.deck');
-    this.slides = [...document.querySelectorAll('.slide')];
+    this.deck = document.querySelector(".deck");
+    this.slides = [...document.querySelectorAll(".slide")];
     this.current = 0;
     this.total = this.slides.length;
     this.buildChrome();
@@ -308,102 +323,129 @@ class SlideEngine {
 
   buildChrome() {
     // Progress bar
-    var bar = document.createElement('div');
-    bar.className = 'deck-progress';
+    var bar = document.createElement("div");
+    bar.className = "deck-progress";
     document.body.appendChild(bar);
     this.bar = bar;
 
     // Nav dots
-    var dots = document.createElement('div');
-    dots.className = 'deck-dots';
+    var dots = document.createElement("div");
+    dots.className = "deck-dots";
     var self = this;
-    this.slides.forEach(function(_, i) {
-      var d = document.createElement('button');
-      d.className = 'deck-dot';
-      d.title = 'Slide ' + (i + 1);
-      d.onclick = function() { self.goTo(i); };
+    this.slides.forEach(function (_, i) {
+      var d = document.createElement("button");
+      d.className = "deck-dot";
+      d.title = "Slide " + (i + 1);
+      d.onclick = function () {
+        self.goTo(i);
+      };
       dots.appendChild(d);
     });
     document.body.appendChild(dots);
     this.dots = [].slice.call(dots.children);
 
     // Counter
-    var ctr = document.createElement('div');
-    ctr.className = 'deck-counter';
+    var ctr = document.createElement("div");
+    ctr.className = "deck-counter";
     document.body.appendChild(ctr);
     this.counter = ctr;
 
     // Keyboard hints
-    var hints = document.createElement('div');
-    hints.className = 'deck-hints';
-    hints.textContent = '\u2190 \u2192 or scroll to navigate';
+    var hints = document.createElement("div");
+    hints.className = "deck-hints";
+    hints.textContent = "\u2190 \u2192 or scroll to navigate";
     document.body.appendChild(hints);
     this.hints = hints;
-    this.hintTimer = setTimeout(function() {
-      hints.classList.add('faded');
+    this.hintTimer = setTimeout(function () {
+      hints.classList.add("faded");
     }, 4000);
   }
 
   bindEvents() {
     var self = this;
     // Keyboard — skip if focus is inside interactive content
-    document.addEventListener('keydown', function(e) {
-      if (e.target.closest('.mermaid-wrap, .table-scroll, .code-scroll, input, textarea, [contenteditable]')) return;
-      if (['ArrowDown', 'ArrowRight', ' ', 'PageDown'].includes(e.key)) {
-        e.preventDefault(); self.next();
-      } else if (['ArrowUp', 'ArrowLeft', 'PageUp'].includes(e.key)) {
-        e.preventDefault(); self.prev();
-      } else if (e.key === 'Home') {
-        e.preventDefault(); self.goTo(0);
-      } else if (e.key === 'End') {
-        e.preventDefault(); self.goTo(self.total - 1);
+    document.addEventListener("keydown", function (e) {
+      if (
+        e.target.closest(
+          ".mermaid-wrap, .table-scroll, .code-scroll, input, textarea, [contenteditable]",
+        )
+      )
+        return;
+      if (["ArrowDown", "ArrowRight", " ", "PageDown"].includes(e.key)) {
+        e.preventDefault();
+        self.next();
+      } else if (["ArrowUp", "ArrowLeft", "PageUp"].includes(e.key)) {
+        e.preventDefault();
+        self.prev();
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        self.goTo(0);
+      } else if (e.key === "End") {
+        e.preventDefault();
+        self.goTo(self.total - 1);
       }
       self.fadeHints();
     });
 
     // Touch swipe
     var touchY;
-    this.deck.addEventListener('touchstart', function(e) {
-      touchY = e.touches[0].clientY;
-    }, { passive: true });
-    this.deck.addEventListener('touchend', function(e) {
+    this.deck.addEventListener(
+      "touchstart",
+      function (e) {
+        touchY = e.touches[0].clientY;
+      },
+      { passive: true },
+    );
+    this.deck.addEventListener("touchend", function (e) {
       var dy = touchY - e.changedTouches[0].clientY;
-      if (Math.abs(dy) > 50) { dy > 0 ? self.next() : self.prev(); }
+      if (Math.abs(dy) > 50) {
+        dy > 0 ? self.next() : self.prev();
+      }
     });
   }
 
   observe() {
     var self = this;
-    var obs = new IntersectionObserver(function(entries) {
-      entries.forEach(function(entry) {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('visible');
-          self.current = self.slides.indexOf(entry.target);
-          self.update();
-        }
-      });
-    }, { threshold: 0.5 });
-    this.slides.forEach(function(s) { obs.observe(s); });
+    var obs = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("visible");
+            self.current = self.slides.indexOf(entry.target);
+            self.update();
+          }
+        });
+      },
+      { threshold: 0.5 },
+    );
+    this.slides.forEach(function (s) {
+      obs.observe(s);
+    });
   }
 
   goTo(i) {
-    this.slides[Math.max(0, Math.min(i, this.total - 1))]
-      .scrollIntoView({ behavior: 'smooth' });
+    this.slides[Math.max(0, Math.min(i, this.total - 1))].scrollIntoView({ behavior: "smooth" });
   }
 
-  next() { if (this.current < this.total - 1) this.goTo(this.current + 1); }
-  prev() { if (this.current > 0) this.goTo(this.current - 1); }
+  next() {
+    if (this.current < this.total - 1) this.goTo(this.current + 1);
+  }
+  prev() {
+    if (this.current > 0) this.goTo(this.current - 1);
+  }
 
   update() {
-    this.bar.style.width = ((this.current + 1) / this.total * 100) + '%';
+    this.bar.style.width = ((this.current + 1) / this.total) * 100 + "%";
     var self = this;
-    this.dots.forEach(function(d, i) { d.classList.toggle('active', i === self.current); });
-    this.counter.textContent = (this.current + 1) + ' / ' + this.total;
+    this.dots.forEach(function (d, i) {
+      d.classList.toggle("active", i === self.current);
+    });
+    this.counter.textContent = this.current + 1 + " / " + this.total;
   }
 
   fadeHints() {
     clearTimeout(this.hintTimer);
-    this.hints.classList.add('faded');
+    this.hints.classList.add("faded");
   }
 }
 ```
@@ -413,7 +455,7 @@ class SlideEngine {
 ```html
 <script>
   // After Mermaid/Chart.js initialization (if used), or at end of <body>:
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener("DOMContentLoaded", function () {
     autoFit();
     new SlideEngine();
   });
@@ -427,36 +469,37 @@ A single post-render function that handles all known content overflow cases. Age
 ```javascript
 function autoFit() {
   // Mermaid SVGs: fill container instead of rendering at intrinsic size
-  document.querySelectorAll('.mermaid svg').forEach(function(svg) {
-    svg.removeAttribute('height');
-    svg.style.width = '100%';
-    svg.style.maxWidth = '100%';
-    svg.style.height = 'auto';
-    svg.parentElement.style.width = '100%';
+  document.querySelectorAll(".mermaid svg").forEach(function (svg) {
+    svg.removeAttribute("height");
+    svg.style.width = "100%";
+    svg.style.maxWidth = "100%";
+    svg.style.height = "auto";
+    svg.parentElement.style.width = "100%";
   });
 
   // KPI values: visually scale down text that overflows card width
-  document.querySelectorAll('.slide__kpi-val').forEach(function(el) {
+  document.querySelectorAll(".slide__kpi-val").forEach(function (el) {
     if (el.scrollWidth > el.clientWidth) {
       var s = el.clientWidth / el.scrollWidth;
-      el.style.transform = 'scale(' + s + ')';
-      el.style.transformOrigin = 'left top';
+      el.style.transform = "scale(" + s + ")";
+      el.style.transformOrigin = "left top";
     }
   });
 
   // Blockquotes: reduce font proportionally for long text
-  document.querySelectorAll('.slide--quote blockquote').forEach(function(el) {
+  document.querySelectorAll(".slide--quote blockquote").forEach(function (el) {
     var len = el.textContent.trim().length;
     if (len > 100) {
       var scale = Math.max(0.5, 100 / len);
       var fs = parseFloat(getComputedStyle(el).fontSize);
-      el.style.fontSize = Math.max(16, Math.round(fs * scale)) + 'px';
+      el.style.fontSize = Math.max(16, Math.round(fs * scale)) + "px";
     }
   });
 }
 ```
 
 Three cases, one function:
+
 - **Mermaid:** SVGs render with fixed dimensions inside flex containers — force them to fill available width.
 - **KPI values:** Long text strings at hero scale overflow card boundaries — `transform: scale()` shrinks visually without reflow.
 - **Blockquotes:** Quotes longer than ~100 characters get proportionally smaller font. The 0.5 floor prevents unreadably small text; if it needs more than 50% shrink, it should have been a content slide.
@@ -565,7 +608,7 @@ Heading + bullets or paragraphs. Asymmetric layout — content offset to one sid
 }
 
 .slide--content .slide__bullets li::before {
-  content: '';
+  content: "";
   position: absolute;
   left: 0;
   top: 18px;
@@ -723,9 +766,18 @@ For simple linear flows (build steps, deployment stages, data pipelines) where M
       <div class="pipeline__file">output-file.md</div>
     </div>
     <div class="pipeline__arrow">
-      <svg viewBox="0 0 24 24" width="20" height="20"><path d="M5 12h14m-4-4l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <svg viewBox="0 0 24 24" width="20" height="20">
+        <path
+          d="M5 12h14m-4-4l4 4-4 4"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
     </div>
-    <div class="pipeline__step"> ... </div>
+    <div class="pipeline__step">...</div>
     <!-- repeat step + arrow pairs -->
   </div>
 </section>
@@ -794,8 +846,14 @@ For simple linear flows (build steps, deployment stages, data pipelines) where M
 }
 
 @media (max-width: 768px) {
-  .pipeline { flex-direction: column; }
-  .pipeline__arrow { justify-content: center; padding: 4px 0; transform: rotate(90deg); }
+  .pipeline {
+    flex-direction: column;
+  }
+  .pipeline__arrow {
+    justify-content: center;
+    padding: 4px 0;
+    transform: rotate(90deg);
+  }
 }
 ```
 
@@ -865,7 +923,9 @@ KPI cards at presentation scale (48–64px hero numbers). Mini-charts via Chart.
   <h2 class="slide__heading reveal">Data Title</h2>
   <div class="table-wrap reveal" style="flex:1; min-height:0;">
     <div class="table-scroll">
-      <table class="data-table"> ... </table>
+      <table class="data-table">
+        ...
+      </table>
     </div>
   </div>
 </section>
@@ -954,9 +1014,7 @@ KPI cards at presentation scale (48–64px hero numbers). Mini-charts via Chart.
 ```html
 <section class="slide slide--quote">
   <div class="slide__quote-mark reveal">&ldquo;</div>
-  <blockquote class="reveal">
-    The best code is the code you don't have to write.
-  </blockquote>
+  <blockquote class="reveal">The best code is the code you don't have to write.</blockquote>
   <cite class="reveal">&mdash; Someone Wise</cite>
 </section>
 ```
@@ -1031,7 +1089,12 @@ Background image (surf-generated or CSS gradient) dominates the viewport. Text o
 .slide__scrim {
   position: absolute;
   inset: 0;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.1) 50%, transparent 100%);
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.7) 0%,
+    rgba(0, 0, 0, 0.1) 50%,
+    transparent 100%
+  );
   z-index: 1;
 }
 
@@ -1043,7 +1106,11 @@ Background image (surf-generated or CSS gradient) dominates the viewport. Text o
 
 /* When no generated image, use a bold CSS gradient background */
 .slide__bg--gradient {
-  background: linear-gradient(135deg, var(--accent) 0%, color-mix(in srgb, var(--accent) 60%, var(--bg) 40%) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--accent) 0%,
+    color-mix(in srgb, var(--accent) 60%, var(--bg) 40%) 100%
+  );
 }
 ```
 
@@ -1056,8 +1123,8 @@ Inline SVG accents lift slides from functional to editorial. Use sparingly — o
 ```html
 <!-- Top-right corner mark -->
 <svg class="slide__decor slide__decor--corner" width="120" height="120" viewBox="0 0 120 120">
-  <line x1="120" y1="0" x2="120" y2="40" stroke="var(--accent)" stroke-width="2" opacity="0.2"/>
-  <line x1="80" y1="0" x2="120" y2="0" stroke="var(--accent)" stroke-width="2" opacity="0.2"/>
+  <line x1="120" y1="0" x2="120" y2="40" stroke="var(--accent)" stroke-width="2" opacity="0.2" />
+  <line x1="80" y1="0" x2="120" y2="0" stroke="var(--accent)" stroke-width="2" opacity="0.2" />
 </svg>
 ```
 
@@ -1079,9 +1146,19 @@ Inline SVG accents lift slides from functional to editorial. Use sparingly — o
 ```html
 <!-- Horizontal rule with diamond -->
 <svg class="slide__decor slide__decor--divider" width="200" height="20" viewBox="0 0 200 20">
-  <line x1="0" y1="10" x2="85" y2="10" stroke="var(--accent)" stroke-width="1" opacity="0.3"/>
-  <rect x="92" y="3" width="14" height="14" transform="rotate(45 99 10)" fill="none" stroke="var(--accent)" stroke-width="1" opacity="0.3"/>
-  <line x1="115" y1="10" x2="200" y2="10" stroke="var(--accent)" stroke-width="1" opacity="0.3"/>
+  <line x1="0" y1="10" x2="85" y2="10" stroke="var(--accent)" stroke-width="1" opacity="0.3" />
+  <rect
+    x="92"
+    y="3"
+    width="14"
+    height="14"
+    transform="rotate(45 99 10)"
+    fill="none"
+    stroke="var(--accent)"
+    stroke-width="1"
+    opacity="0.3"
+  />
+  <line x1="115" y1="10" x2="200" y2="10" stroke="var(--accent)" stroke-width="1" opacity="0.3" />
 </svg>
 ```
 
@@ -1090,7 +1167,7 @@ Inline SVG accents lift slides from functional to editorial. Use sparingly — o
 ```css
 /* Faint grid dots behind a slide */
 .slide--with-grid::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   background-image: radial-gradient(circle, var(--border) 1px, transparent 1px);
@@ -1147,6 +1224,7 @@ rm /tmp/ve-slide-title.png
 ```
 
 **Prompt craft for slides:** Be specific about style, dominant colors, and mood. Pull colors from the preset's CSS variables. Examples:
+
 - Terminal Mono: "dark abstract circuit board pattern, green (#50fa7b) traces on near-black (#0a0e14), minimal, technical"
 - Midnight Editorial: "deep navy abstract composition, warm gold accent light, cinematic depth of field, premium editorial feel"
 - Warm Signal: "warm cream textured paper with terracotta geometric accents, confident modern design"
@@ -1162,6 +1240,7 @@ rm /tmp/ve-slide-title.png
 Consecutive slides must vary their spatial approach. Three centered slides in a row means push one off-axis.
 
 **Composition patterns to alternate between:**
+
 - Centered (title slides, quotes)
 - Left-heavy: content on the left 60%, breathing room on the right
 - Right-heavy: content on the right 60%, visual or whitespace on the left
@@ -1185,18 +1264,18 @@ Slides get projected, screen-shared, viewed at distance. Design accordingly:
 
 Each slide must fit in exactly 100dvh. If content exceeds these limits, the agent splits across multiple slides — never scrolls within a slide.
 
-| Slide type | Max content |
-|-----------|-------------|
-| Title | 1 heading + 1 subtitle |
-| Section Divider | 1 number + 1 heading + optional subhead |
-| Content | 1 heading + 5–6 bullets (max 2 lines each) |
-| Split | 1 heading + 2 panels, each follows its inner type's limits |
-| Diagram | 1 heading + 1 Mermaid diagram (max 8–10 nodes) |
-| Dashboard | 1 heading + 6 KPI cards. Hero values ≤6 chars (numbers, %, short labels). Longer strings belong in the label row. |
-| Table | 1 heading + 8 rows; overflow paginates to next slide |
-| Code | 1 heading + 10 lines of code |
-| Quote | 1 short quote (~25 words / ~150 chars max) + 1 attribution. Longer quotes are content slides, not quote slides. |
-| Full-Bleed | 1 heading + 1 subtitle over background |
+| Slide type      | Max content                                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Title           | 1 heading + 1 subtitle                                                                                            |
+| Section Divider | 1 number + 1 heading + optional subhead                                                                           |
+| Content         | 1 heading + 5–6 bullets (max 2 lines each)                                                                        |
+| Split           | 1 heading + 2 panels, each follows its inner type's limits                                                        |
+| Diagram         | 1 heading + 1 Mermaid diagram (max 8–10 nodes)                                                                    |
+| Dashboard       | 1 heading + 6 KPI cards. Hero values ≤6 chars (numbers, %, short labels). Longer strings belong in the label row. |
+| Table           | 1 heading + 8 rows; overflow paginates to next slide                                                              |
+| Code            | 1 heading + 10 lines of code                                                                                      |
+| Quote           | 1 short quote (~25 words / ~150 chars max) + 1 attribution. Longer quotes are content slides, not quote slides.   |
+| Full-Bleed      | 1 heading + 1 subtitle over background                                                                            |
 
 ## Responsive Height Breakpoints
 
@@ -1208,15 +1287,25 @@ Height-based scaling is more critical for slides than width. Each breakpoint pro
   .slide {
     padding: clamp(24px, 4vh, 40px) clamp(32px, 6vw, 80px);
   }
-  .slide__display { font-size: clamp(36px, 8vw, 72px); }
-  .slide--divider .slide__number { font-size: clamp(80px, 16vw, 160px); }
+  .slide__display {
+    font-size: clamp(36px, 8vw, 72px);
+  }
+  .slide--divider .slide__number {
+    font-size: clamp(80px, 16vw, 160px);
+  }
 }
 
 /* Small tablets / landscape phones */
 @media (max-height: 600px) {
-  .slide__decor { display: none; } /* hide decorative SVGs */
-  .slide--quote { padding: clamp(32px, 6vh, 60px) clamp(40px, 8vw, 100px); }
-  .slide__quote-mark { display: none; }
+  .slide__decor {
+    display: none;
+  } /* hide decorative SVGs */
+  .slide--quote {
+    padding: clamp(32px, 6vh, 60px) clamp(40px, 8vw, 100px);
+  }
+  .slide__quote-mark {
+    display: none;
+  }
 }
 
 /* Aggressive: landscape phones */
@@ -1224,16 +1313,28 @@ Height-based scaling is more critical for slides than width. Each breakpoint pro
   .slide {
     padding: clamp(16px, 3vh, 24px) clamp(24px, 5vw, 48px);
   }
-  .deck-dots { display: none; } /* dots clutter tiny viewports */
-  .slide__display { font-size: clamp(28px, 7vw, 48px); }
+  .deck-dots {
+    display: none;
+  } /* dots clutter tiny viewports */
+  .slide__display {
+    font-size: clamp(28px, 7vw, 48px);
+  }
 }
 
 /* Width breakpoint for grids */
 @media (max-width: 768px) {
-  .slide--content .slide__inner { grid-template-columns: 1fr; }
-  .slide--content .slide__aside { display: none; }
-  .slide--split .slide__panels { grid-template-columns: 1fr; }
-  .slide--dashboard .slide__kpis { grid-template-columns: repeat(2, 1fr); }
+  .slide--content .slide__inner {
+    grid-template-columns: 1fr;
+  }
+  .slide--content .slide__aside {
+    display: none;
+  }
+  .slide--split .slide__panels {
+    grid-template-columns: 1fr;
+  }
+  .slide--dashboard .slide__kpis {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 ```
 
@@ -1247,8 +1348,8 @@ Deep navy, serif display, warm gold accents. Cinematic, premium. Dark-first.
 
 ```css
 :root {
-  --font-body: 'Instrument Serif', Georgia, serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', monospace;
+  --font-body: "Instrument Serif", Georgia, serif;
+  --font-mono: "JetBrains Mono", "SF Mono", monospace;
   --bg: #0f1729;
   --surface: #162040;
   --surface2: #1d2b52;
@@ -1288,8 +1389,8 @@ Cream paper, bold sans, terracotta/coral accents. Confident and modern. Light-fi
 
 ```css
 :root {
-  --font-body: 'Plus Jakarta Sans', system-ui, sans-serif;
-  --font-mono: 'Azeret Mono', 'SF Mono', monospace;
+  --font-body: "Plus Jakarta Sans", system-ui, sans-serif;
+  --font-mono: "Azeret Mono", "SF Mono", monospace;
   --bg: #faf6f0;
   --surface: #ffffff;
   --surface2: #f5ece0;
@@ -1329,8 +1430,8 @@ Dark, monospace everything, green/cyan accents, faint grid. Developer-native. Da
 
 ```css
 :root {
-  --font-body: 'Geist Mono', 'SF Mono', Consolas, monospace;
-  --font-mono: 'Geist Mono', 'SF Mono', Consolas, monospace;
+  --font-body: "Geist Mono", "SF Mono", Consolas, monospace;
+  --font-mono: "Geist Mono", "SF Mono", Consolas, monospace;
   --bg: #0a0e14;
   --surface: #12161e;
   --surface2: #1a1f2a;
@@ -1370,8 +1471,8 @@ White, geometric sans, single bold accent, visible grid. Minimal and precise. Li
 
 ```css
 :root {
-  --font-body: 'DM Sans', system-ui, sans-serif;
-  --font-mono: 'Fira Code', 'SF Mono', monospace;
+  --font-body: "DM Sans", system-ui, sans-serif;
+  --font-mono: "Fira Code", "SF Mono", monospace;
   --bg: #ffffff;
   --surface: #f8f8f8;
   --surface2: #f0f0f0;

--- a/plugins/visual-explainer/templates/architecture.html
+++ b/plugins/visual-explainer/templates/architecture.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Architecture Diagram — Reference Template</title>
-<!--
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Architecture Diagram — Reference Template</title>
+    <!--
   Reference template for the visual-explainer skill: CSS Grid architecture layout.
   Warm terracotta/sage palette — distinctly different from the teal (mermaid)
   and rose (data-table) templates so agents absorb variety, not a single palette.
@@ -21,576 +21,682 @@
   - Staggered fade-in via --i CSS variable (works with interleaved elements)
   - Reduced motion respect, responsive single-column fallback
 -->
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-<style>
-  /* ============ THEME ============ */
-  :root {
-    --font-body: 'IBM Plex Sans', system-ui, sans-serif;
-    --font-mono: 'IBM Plex Mono', 'SF Mono', Consolas, monospace;
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============ THEME ============ */
+      :root {
+        --font-body: "IBM Plex Sans", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", "SF Mono", Consolas, monospace;
 
-    /* Light theme — warm terracotta + sage palette */
-    --bg: #faf7f5;
-    --surface: #ffffff;
-    --surface2: #f5f0ec;
-    --surface-elevated: #fff9f5;
-    --border: rgba(0, 0, 0, 0.07);
-    --border-bright: rgba(0, 0, 0, 0.14);
-    --text: #292017;
-    --text-dim: #8a7e72;
-    --accent: #c2410c;
-    --accent-dim: rgba(194, 65, 12, 0.07);
-    --green: #4d7c0f;
-    --green-dim: rgba(77, 124, 15, 0.07);
-    --orange: #b45309;
-    --orange-dim: rgba(180, 83, 9, 0.07);
-    --sage: #65a30d;
-    --sage-dim: rgba(101, 163, 13, 0.07);
-    --teal: #0f766e;
-    --teal-dim: rgba(15, 118, 110, 0.07);
-    --plum: #9f1239;
-    --plum-dim: rgba(159, 18, 57, 0.07);
-  }
+        /* Light theme — warm terracotta + sage palette */
+        --bg: #faf7f5;
+        --surface: #ffffff;
+        --surface2: #f5f0ec;
+        --surface-elevated: #fff9f5;
+        --border: rgba(0, 0, 0, 0.07);
+        --border-bright: rgba(0, 0, 0, 0.14);
+        --text: #292017;
+        --text-dim: #8a7e72;
+        --accent: #c2410c;
+        --accent-dim: rgba(194, 65, 12, 0.07);
+        --green: #4d7c0f;
+        --green-dim: rgba(77, 124, 15, 0.07);
+        --orange: #b45309;
+        --orange-dim: rgba(180, 83, 9, 0.07);
+        --sage: #65a30d;
+        --sage-dim: rgba(101, 163, 13, 0.07);
+        --teal: #0f766e;
+        --teal-dim: rgba(15, 118, 110, 0.07);
+        --plum: #9f1239;
+        --plum-dim: rgba(159, 18, 57, 0.07);
+      }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #1a1412;
-      --surface: #231d1a;
-      --surface2: #2e2622;
-      --surface-elevated: #352d28;
-      --border: rgba(255, 255, 255, 0.06);
-      --border-bright: rgba(255, 255, 255, 0.12);
-      --text: #ede5dd;
-      --text-dim: #a69889;
-      --accent: #fb923c;
-      --accent-dim: rgba(251, 146, 60, 0.12);
-      --green: #a3e635;
-      --green-dim: rgba(163, 230, 53, 0.1);
-      --orange: #fbbf24;
-      --orange-dim: rgba(251, 191, 36, 0.1);
-      --sage: #bef264;
-      --sage-dim: rgba(190, 242, 100, 0.1);
-      --teal: #5eead4;
-      --teal-dim: rgba(94, 234, 212, 0.1);
-      --plum: #fda4af;
-      --plum-dim: rgba(253, 164, 175, 0.1);
-    }
-  }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #1a1412;
+          --surface: #231d1a;
+          --surface2: #2e2622;
+          --surface-elevated: #352d28;
+          --border: rgba(255, 255, 255, 0.06);
+          --border-bright: rgba(255, 255, 255, 0.12);
+          --text: #ede5dd;
+          --text-dim: #a69889;
+          --accent: #fb923c;
+          --accent-dim: rgba(251, 146, 60, 0.12);
+          --green: #a3e635;
+          --green-dim: rgba(163, 230, 53, 0.1);
+          --orange: #fbbf24;
+          --orange-dim: rgba(251, 191, 36, 0.1);
+          --sage: #bef264;
+          --sage-dim: rgba(190, 242, 100, 0.1);
+          --teal: #5eead4;
+          --teal-dim: rgba(94, 234, 212, 0.1);
+          --plum: #fda4af;
+          --plum-dim: rgba(253, 164, 175, 0.1);
+        }
+      }
 
-  /* ============ RESET + BASE ============ */
-  * { margin: 0; padding: 0; box-sizing: border-box; }
+      /* ============ RESET + BASE ============ */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  body {
-    background: var(--bg);
-    background-image:
-      radial-gradient(ellipse at 20% 0%, var(--accent-dim) 0%, transparent 50%),
-      radial-gradient(ellipse at 80% 100%, var(--sage-dim) 0%, transparent 40%);
-    color: var(--text);
-    font-family: var(--font-body);
-    padding: 40px;
-    min-height: 100vh;
-  }
+      body {
+        background: var(--bg);
+        background-image:
+          radial-gradient(ellipse at 20% 0%, var(--accent-dim) 0%, transparent 50%),
+          radial-gradient(ellipse at 80% 100%, var(--sage-dim) 0%, transparent 40%);
+        color: var(--text);
+        font-family: var(--font-body);
+        padding: 40px;
+        min-height: 100vh;
+      }
 
-  /* ============ ANIMATION ============ */
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(12px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
+      /* ============ ANIMATION ============ */
+      @keyframes fadeUp {
+        from {
+          opacity: 0;
+          transform: translateY(12px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
 
-  .section, .flow-arrow {
-    animation: fadeUp 0.4s ease-out both;
-    animation-delay: calc(var(--i, 0) * 0.06s);
-  }
+      .section,
+      .flow-arrow {
+        animation: fadeUp 0.4s ease-out both;
+        animation-delay: calc(var(--i, 0) * 0.06s);
+      }
 
-  @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
-      animation-duration: 0.01ms !important;
-      animation-delay: 0ms !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-delay: 0ms !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  /* ============ TYPOGRAPHY ============ */
-  h1 {
-    font-size: 38px;
-    font-weight: 700;
-    letter-spacing: -1px;
-    margin-bottom: 6px;
-    text-wrap: balance;
-  }
+      /* ============ TYPOGRAPHY ============ */
+      h1 {
+        font-size: 38px;
+        font-weight: 700;
+        letter-spacing: -1px;
+        margin-bottom: 6px;
+        text-wrap: balance;
+      }
 
-  .subtitle {
-    color: var(--text-dim);
-    font-size: 14px;
-    margin-bottom: 40px;
-    font-family: var(--font-mono);
-  }
+      .subtitle {
+        color: var(--text-dim);
+        font-size: 14px;
+        margin-bottom: 40px;
+        font-family: var(--font-mono);
+      }
 
-  /* ============ LAYOUT ============ */
-  .diagram {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 24px;
-    max-width: 1100px;
-    margin: 0 auto;
-  }
+      /* ============ LAYOUT ============ */
+      .diagram {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 24px;
+        max-width: 1100px;
+        margin: 0 auto;
+      }
 
-  /* ============ SECTION CARD ============ */
-  .section {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 20px 24px;
-  }
+      /* ============ SECTION CARD ============ */
+      .section {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 20px 24px;
+      }
 
-  .section--hero {
-    background: var(--surface-elevated);
-    border-color: color-mix(in srgb, var(--border) 50%, var(--accent) 50%);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
-    padding: 28px 32px;
-  }
+      .section--hero {
+        background: var(--surface-elevated);
+        border-color: color-mix(in srgb, var(--border) 50%, var(--accent) 50%);
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+        padding: 28px 32px;
+      }
 
-  .section--recessed {
-    background: var(--surface2);
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
-  }
+      .section--recessed {
+        background: var(--surface2);
+        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
+      }
 
-  .section-label {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    margin-bottom: 16px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
+      .section-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1.5px;
+        margin-bottom: 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
 
-  .section-label .dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    display: inline-block;
-  }
+      .section-label .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        display: inline-block;
+      }
 
-  /* Color variants */
-  .section--accent { border-color: var(--accent-dim); }
-  .section--accent .section-label { color: var(--accent); }
-  .section--accent .section-label .dot { background: var(--accent); }
+      /* Color variants */
+      .section--accent {
+        border-color: var(--accent-dim);
+      }
+      .section--accent .section-label {
+        color: var(--accent);
+      }
+      .section--accent .section-label .dot {
+        background: var(--accent);
+      }
 
-  .section--green { border-color: var(--green-dim); }
-  .section--green .section-label { color: var(--green); }
-  .section--green .section-label .dot { background: var(--green); }
+      .section--green {
+        border-color: var(--green-dim);
+      }
+      .section--green .section-label {
+        color: var(--green);
+      }
+      .section--green .section-label .dot {
+        background: var(--green);
+      }
 
-  .section--orange { border-color: var(--orange-dim); }
-  .section--orange .section-label { color: var(--orange); }
-  .section--orange .section-label .dot { background: var(--orange); }
+      .section--orange {
+        border-color: var(--orange-dim);
+      }
+      .section--orange .section-label {
+        color: var(--orange);
+      }
+      .section--orange .section-label .dot {
+        background: var(--orange);
+      }
 
-  .section--sage { border-color: var(--sage-dim); }
-  .section--sage .section-label { color: var(--sage); }
-  .section--sage .section-label .dot { background: var(--sage); }
+      .section--sage {
+        border-color: var(--sage-dim);
+      }
+      .section--sage .section-label {
+        color: var(--sage);
+      }
+      .section--sage .section-label .dot {
+        background: var(--sage);
+      }
 
-  .section--teal { border-color: var(--teal-dim); }
-  .section--teal .section-label { color: var(--teal); }
-  .section--teal .section-label .dot { background: var(--teal); }
+      .section--teal {
+        border-color: var(--teal-dim);
+      }
+      .section--teal .section-label {
+        color: var(--teal);
+      }
+      .section--teal .section-label .dot {
+        background: var(--teal);
+      }
 
-  .section--plum { border-color: var(--plum-dim); }
-  .section--plum .section-label { color: var(--plum); }
-  .section--plum .section-label .dot { background: var(--plum); }
+      .section--plum {
+        border-color: var(--plum-dim);
+      }
+      .section--plum .section-label {
+        color: var(--plum);
+      }
+      .section--plum .section-label .dot {
+        background: var(--plum);
+      }
 
-  /* ============ INNER GRID ============ */
-  .inner-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
+      /* ============ INNER GRID ============ */
+      .inner-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
 
-  .inner-card {
-    background: var(--surface2);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 12px 16px;
-  }
+      .inner-card {
+        background: var(--surface2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px 16px;
+      }
 
-  .inner-card .title {
-    font-weight: 600;
-    font-size: 13px;
-    margin-bottom: 4px;
-  }
+      .inner-card .title {
+        font-weight: 600;
+        font-size: 13px;
+        margin-bottom: 4px;
+      }
 
-  .inner-card .desc {
-    color: var(--text-dim);
-    font-size: 12px;
-    line-height: 1.5;
-  }
+      .inner-card .desc {
+        color: var(--text-dim);
+        font-size: 12px;
+        line-height: 1.5;
+      }
 
-  .inner-card code {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    background: var(--accent-dim);
-    color: var(--accent);
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
+      .inner-card code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--accent-dim);
+        color: var(--accent);
+        padding: 1px 5px;
+        border-radius: 3px;
+      }
 
-  /* ============ FLOW ARROW ============ */
-  .flow-arrow {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-    color: var(--text-dim);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    padding: 4px 0;
-  }
+      /* ============ FLOW ARROW ============ */
+      .flow-arrow {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        color: var(--text-dim);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        padding: 4px 0;
+      }
 
-  .flow-arrow svg {
-    width: 20px;
-    height: 20px;
-    fill: none;
-    stroke: var(--border-bright);
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
+      .flow-arrow svg {
+        width: 20px;
+        height: 20px;
+        fill: none;
+        stroke: var(--border-bright);
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
 
-  /* ============ PIPELINE ============ */
-  .pipeline {
-    display: flex;
-    gap: 0;
-    align-items: stretch;
-    overflow-x: auto;
-    padding-bottom: 4px;
-  }
+      /* ============ PIPELINE ============ */
+      .pipeline {
+        display: flex;
+        gap: 0;
+        align-items: stretch;
+        overflow-x: auto;
+        padding-bottom: 4px;
+      }
 
-  .pipeline-step {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 10px 12px;
-    min-width: 120px;
-    flex-shrink: 0;
-    text-align: center;
-  }
+      .pipeline-step {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px 12px;
+        min-width: 120px;
+        flex-shrink: 0;
+        text-align: center;
+      }
 
-  .pipeline-step .step-num {
-    font-family: var(--font-mono);
-    font-size: 10px;
-    font-weight: 600;
-    margin-bottom: 4px;
-  }
+      .pipeline-step .step-num {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
 
-  .pipeline-step .step-name {
-    font-size: 12px;
-    font-weight: 600;
-    margin-bottom: 3px;
-  }
+      .pipeline-step .step-name {
+        font-size: 12px;
+        font-weight: 600;
+        margin-bottom: 3px;
+      }
 
-  .pipeline-step .step-detail {
-    font-size: 10px;
-    color: var(--text-dim);
-    line-height: 1.4;
-  }
+      .pipeline-step .step-detail {
+        font-size: 10px;
+        color: var(--text-dim);
+        line-height: 1.4;
+      }
 
-  /* Step color variants */
-  .pipeline-step--teal { border-color: var(--teal-dim); }
-  .pipeline-step--teal .step-num { color: var(--teal); }
+      /* Step color variants */
+      .pipeline-step--teal {
+        border-color: var(--teal-dim);
+      }
+      .pipeline-step--teal .step-num {
+        color: var(--teal);
+      }
 
-  .pipeline-step--sage { border-color: var(--sage-dim); }
-  .pipeline-step--sage .step-num { color: var(--sage); }
+      .pipeline-step--sage {
+        border-color: var(--sage-dim);
+      }
+      .pipeline-step--sage .step-num {
+        color: var(--sage);
+      }
 
-  .pipeline-step--orange { border-color: var(--orange-dim); }
-  .pipeline-step--orange .step-num { color: var(--orange); }
+      .pipeline-step--orange {
+        border-color: var(--orange-dim);
+      }
+      .pipeline-step--orange .step-num {
+        color: var(--orange);
+      }
 
-  .pipeline-step--green { border-color: var(--green-dim); }
-  .pipeline-step--green .step-num { color: var(--green); }
+      .pipeline-step--green {
+        border-color: var(--green-dim);
+      }
+      .pipeline-step--green .step-num {
+        color: var(--green);
+      }
 
-  .pipeline-arrow {
-    display: flex;
-    align-items: center;
-    padding: 0 2px;
-    color: var(--border-bright);
-    font-size: 16px;
-    flex-shrink: 0;
-  }
+      .pipeline-arrow {
+        display: flex;
+        align-items: center;
+        padding: 0 2px;
+        color: var(--border-bright);
+        font-size: 16px;
+        flex-shrink: 0;
+      }
 
-  .pipeline-parallel {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
+      .pipeline-parallel {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
 
-  /* ============ THREE COLUMN ROW ============ */
-  .three-col {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 16px;
-  }
+      /* ============ THREE COLUMN ROW ============ */
+      .three-col {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 16px;
+      }
 
-  /* ============ LIST ============ */
-  .node-list {
-    list-style: none;
-    font-size: 12px;
-    line-height: 1.8;
-  }
+      /* ============ LIST ============ */
+      .node-list {
+        list-style: none;
+        font-size: 12px;
+        line-height: 1.8;
+      }
 
-  .node-list li {
-    padding-left: 14px;
-    position: relative;
-  }
+      .node-list li {
+        padding-left: 14px;
+        position: relative;
+      }
 
-  .node-list li::before {
-    content: '›';
-    color: var(--text-dim);
-    font-weight: 600;
-    position: absolute;
-    left: 0;
-  }
+      .node-list li::before {
+        content: "›";
+        color: var(--text-dim);
+        font-weight: 600;
+        position: absolute;
+        left: 0;
+      }
 
-  .node-list code {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    background: var(--accent-dim);
-    color: var(--accent);
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
+      .node-list code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--accent-dim);
+        color: var(--accent);
+        padding: 1px 5px;
+        border-radius: 3px;
+      }
 
-  /* ============ CALLOUT ============ */
-  .callout {
-    background: var(--surface2);
-    border: 1px solid var(--border);
-    border-left: 3px solid var(--accent);
-    border-radius: 0 8px 8px 0;
-    padding: 14px 18px;
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--text-dim);
-  }
+      /* ============ CALLOUT ============ */
+      .callout {
+        background: var(--surface2);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: 0 8px 8px 0;
+        padding: 14px 18px;
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--text-dim);
+      }
 
-  .callout strong { color: var(--text); font-weight: 600; }
+      .callout strong {
+        color: var(--text);
+        font-weight: 600;
+      }
 
-  .callout code {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    background: var(--accent-dim);
-    color: var(--accent);
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
+      .callout code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--accent-dim);
+        color: var(--accent);
+        padding: 1px 5px;
+        border-radius: 3px;
+      }
 
-  /* ============ LEGEND ============ */
-  .legend {
-    display: flex;
-    gap: 20px;
-    flex-wrap: wrap;
-  }
+      /* ============ LEGEND ============ */
+      .legend {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+      }
 
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    color: var(--text-dim);
-    font-family: var(--font-mono);
-  }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        color: var(--text-dim);
+        font-family: var(--font-mono);
+      }
 
-  .legend-swatch {
-    width: 12px;
-    height: 12px;
-    border-radius: 3px;
-  }
+      .legend-swatch {
+        width: 12px;
+        height: 12px;
+        border-radius: 3px;
+      }
 
-  /* ============ SOURCE PILLS ============ */
-  .sources {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
+      /* ============ SOURCE PILLS ============ */
+      .sources {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
 
-  .source {
-    background: var(--surface2);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 10px 18px;
-    font-family: var(--font-mono);
-    font-size: 13px;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    transition: border-color 0.2s;
-  }
+      .source {
+        background: var(--surface2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px 18px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        transition: border-color 0.2s;
+      }
 
-  .source:hover { border-color: var(--border-bright); }
+      .source:hover {
+        border-color: var(--border-bright);
+      }
 
-  /* ============ RESPONSIVE ============ */
-  @media (max-width: 768px) {
-    body { padding: 20px; }
-    .inner-grid { grid-template-columns: 1fr; }
-    .three-col { grid-template-columns: 1fr; }
-    .pipeline { flex-wrap: wrap; gap: 6px; }
-    .pipeline-arrow { display: none; }
-  }
-</style>
-</head>
-<body>
+      /* ============ RESPONSIVE ============ */
+      @media (max-width: 768px) {
+        body {
+          padding: 20px;
+        }
+        .inner-grid {
+          grid-template-columns: 1fr;
+        }
+        .three-col {
+          grid-template-columns: 1fr;
+        }
+        .pipeline {
+          flex-wrap: wrap;
+          gap: 6px;
+        }
+        .pipeline-arrow {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>System Architecture</h1>
+    <p class="subtitle">reference template &mdash; architecture diagram pattern</p>
 
-<h1>System Architecture</h1>
-<p class="subtitle">reference template &mdash; architecture diagram pattern</p>
-
-<div class="diagram">
-
-  <!-- Source pills row — hero depth for the entry point -->
-  <div class="section section--hero" style="--i:0">
-    <div class="section-label"><span class="dot" style="background:var(--text-dim)"></span> Input Sources</div>
-    <div class="sources">
-      <div class="source"><span>💬</span> Slack</div>
-      <div class="source"><span>🐙</span> GitHub</div>
-      <div class="source"><span>📧</span> Email</div>
-    </div>
-  </div>
-
-  <!-- Flow arrow -->
-  <div class="flow-arrow" style="--i:1">
-    <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12"/></svg>
-    incoming events
-  </div>
-
-  <!-- Gateway section with inner grid -->
-  <div class="section section--accent" style="--i:2">
-    <div class="section-label"><span class="dot"></span> Gateway Layer</div>
-    <div class="inner-grid">
-      <div class="inner-card">
-        <div class="title">Router</div>
-        <div class="desc">Routes messages to agents via <code>resolveRoute()</code></div>
-      </div>
-      <div class="inner-card">
-        <div class="title">HTTP Server</div>
-        <div class="desc">Plugin routes + handlers for webhooks and API</div>
-      </div>
-    </div>
-  </div>
-
-  <div class="flow-arrow" style="--i:3">
-    <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12"/></svg>
-    pipeline entry
-  </div>
-
-  <!-- Pipeline section -->
-  <div class="section section--green" style="--i:4">
-    <div class="section-label"><span class="dot"></span> Processing Pipeline</div>
-    <div class="legend" style="margin-bottom:14px">
-      <div class="legend-item"><div class="legend-swatch" style="background:var(--teal-dim);border:1px solid var(--teal)"></div>no LLM</div>
-      <div class="legend-item"><div class="legend-swatch" style="background:var(--sage-dim);border:1px solid var(--sage)"></div>LLM call</div>
-      <div class="legend-item"><div class="legend-swatch" style="background:var(--orange-dim);border:1px solid var(--orange)"></div>embedding</div>
-      <div class="legend-item"><div class="legend-swatch" style="background:var(--green-dim);border:1px solid var(--green)"></div>DB write</div>
-    </div>
-    <div class="pipeline">
-      <div class="pipeline-step pipeline-step--teal">
-        <div class="step-num">STEP 0</div>
-        <div class="step-name">Pre-filter</div>
-        <div class="step-detail">Allowlist, bots,<br>dedup check</div>
-      </div>
-      <div class="pipeline-arrow">→</div>
-      <div class="pipeline-step pipeline-step--sage">
-        <div class="step-num">STEP 1</div>
-        <div class="step-name">Relevance</div>
-        <div class="step-detail">Cheap LLM<br>boolean check</div>
-      </div>
-      <div class="pipeline-arrow">→</div>
-      <div class="pipeline-step pipeline-step--sage">
-        <div class="step-num">STEP 2</div>
-        <div class="step-name">Classify</div>
-        <div class="step-detail">JSON schema<br>validated output</div>
-      </div>
-      <div class="pipeline-arrow">→</div>
-      <div class="pipeline-parallel">
-        <div class="pipeline-step pipeline-step--orange">
-          <div class="step-num">STEP 3</div>
-          <div class="step-name">Embed</div>
-          <div class="step-detail">Vector embedding</div>
+    <div class="diagram">
+      <!-- Source pills row — hero depth for the entry point -->
+      <div class="section section--hero" style="--i: 0">
+        <div class="section-label">
+          <span class="dot" style="background: var(--text-dim)"></span> Input Sources
         </div>
-        <div class="pipeline-step pipeline-step--teal">
-          <div class="step-num">STEP 5</div>
-          <div class="step-name">Enrich</div>
-          <div class="step-detail">User resolution</div>
+        <div class="sources">
+          <div class="source"><span>💬</span> Slack</div>
+          <div class="source"><span>🐙</span> GitHub</div>
+          <div class="source"><span>📧</span> Email</div>
         </div>
       </div>
-      <div class="pipeline-arrow">→</div>
-      <div class="pipeline-step pipeline-step--green">
-        <div class="step-num">STEP 4</div>
-        <div class="step-name">Cluster</div>
-        <div class="step-detail">Cosine similarity<br>+ INSERT</div>
+
+      <!-- Flow arrow -->
+      <div class="flow-arrow" style="--i: 1">
+        <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12" /></svg>
+        incoming events
+      </div>
+
+      <!-- Gateway section with inner grid -->
+      <div class="section section--accent" style="--i: 2">
+        <div class="section-label"><span class="dot"></span> Gateway Layer</div>
+        <div class="inner-grid">
+          <div class="inner-card">
+            <div class="title">Router</div>
+            <div class="desc">Routes messages to agents via <code>resolveRoute()</code></div>
+          </div>
+          <div class="inner-card">
+            <div class="title">HTTP Server</div>
+            <div class="desc">Plugin routes + handlers for webhooks and API</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flow-arrow" style="--i: 3">
+        <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12" /></svg>
+        pipeline entry
+      </div>
+
+      <!-- Pipeline section -->
+      <div class="section section--green" style="--i: 4">
+        <div class="section-label"><span class="dot"></span> Processing Pipeline</div>
+        <div class="legend" style="margin-bottom: 14px">
+          <div class="legend-item">
+            <div
+              class="legend-swatch"
+              style="background: var(--teal-dim); border: 1px solid var(--teal)"
+            ></div>
+            no LLM
+          </div>
+          <div class="legend-item">
+            <div
+              class="legend-swatch"
+              style="background: var(--sage-dim); border: 1px solid var(--sage)"
+            ></div>
+            LLM call
+          </div>
+          <div class="legend-item">
+            <div
+              class="legend-swatch"
+              style="background: var(--orange-dim); border: 1px solid var(--orange)"
+            ></div>
+            embedding
+          </div>
+          <div class="legend-item">
+            <div
+              class="legend-swatch"
+              style="background: var(--green-dim); border: 1px solid var(--green)"
+            ></div>
+            DB write
+          </div>
+        </div>
+        <div class="pipeline">
+          <div class="pipeline-step pipeline-step--teal">
+            <div class="step-num">STEP 0</div>
+            <div class="step-name">Pre-filter</div>
+            <div class="step-detail">Allowlist, bots,<br />dedup check</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-step pipeline-step--sage">
+            <div class="step-num">STEP 1</div>
+            <div class="step-name">Relevance</div>
+            <div class="step-detail">Cheap LLM<br />boolean check</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-step pipeline-step--sage">
+            <div class="step-num">STEP 2</div>
+            <div class="step-name">Classify</div>
+            <div class="step-detail">JSON schema<br />validated output</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-parallel">
+            <div class="pipeline-step pipeline-step--orange">
+              <div class="step-num">STEP 3</div>
+              <div class="step-name">Embed</div>
+              <div class="step-detail">Vector embedding</div>
+            </div>
+            <div class="pipeline-step pipeline-step--teal">
+              <div class="step-num">STEP 5</div>
+              <div class="step-name">Enrich</div>
+              <div class="step-detail">User resolution</div>
+            </div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-step pipeline-step--green">
+            <div class="step-num">STEP 4</div>
+            <div class="step-name">Cluster</div>
+            <div class="step-detail">Cosine similarity<br />+ INSERT</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flow-arrow" style="--i: 5">
+        <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12" /></svg>
+        stored and queryable
+      </div>
+
+      <!-- Database section -->
+      <div class="section section--orange" style="--i: 6">
+        <div class="section-label"><span class="dot"></span> Database</div>
+        <div class="inner-grid">
+          <div class="inner-card">
+            <div class="title">feedback_items</div>
+            <div class="desc">Classification, embedding, cluster assignment, source dedup</div>
+          </div>
+          <div class="inner-card">
+            <div class="title">clusters</div>
+            <div class="desc">Centroid vectors, trends, ticket links, severity rollup</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flow-arrow" style="--i: 7">
+        <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12" /></svg>
+        consumed by
+      </div>
+
+      <!-- Three column output -->
+      <div class="three-col">
+        <div class="section section--sage" style="--i: 8">
+          <div class="section-label"><span class="dot"></span> Agent Tools</div>
+          <ul class="node-list">
+            <li><code>search</code> semantic vector search</li>
+            <li><code>clusters</code> browse and filter</li>
+            <li><code>stats</code> aggregate metrics</li>
+          </ul>
+        </div>
+        <div class="section section--plum" style="--i: 9">
+          <div class="section-label"><span class="dot"></span> Actions</div>
+          <ul class="node-list">
+            <li>Create tickets from clusters</li>
+            <li>Notify customers on ship</li>
+            <li>Generate release notes</li>
+          </ul>
+        </div>
+        <div class="section section--teal" style="--i: 10">
+          <div class="section-label"><span class="dot"></span> Dashboard</div>
+          <ul class="node-list">
+            <li>Metrics overview</li>
+            <li>Feedback stream</li>
+            <li>NL chat interface</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Callout — recessed depth for secondary info -->
+      <div class="callout section section--recessed" style="--i: 11">
+        <strong>Multi-tenant</strong> &mdash; Each agent gets an isolated database at
+        <code>{agentDir}/intelligence/feedback.db</code> with per-agent config overlay and
+        credential isolation.
       </div>
     </div>
-  </div>
-
-  <div class="flow-arrow" style="--i:5">
-    <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12"/></svg>
-    stored and queryable
-  </div>
-
-  <!-- Database section -->
-  <div class="section section--orange" style="--i:6">
-    <div class="section-label"><span class="dot"></span> Database</div>
-    <div class="inner-grid">
-      <div class="inner-card">
-        <div class="title">feedback_items</div>
-        <div class="desc">Classification, embedding, cluster assignment, source dedup</div>
-      </div>
-      <div class="inner-card">
-        <div class="title">clusters</div>
-        <div class="desc">Centroid vectors, trends, ticket links, severity rollup</div>
-      </div>
-    </div>
-  </div>
-
-  <div class="flow-arrow" style="--i:7">
-    <svg viewBox="0 0 20 20"><path d="M10 4 L10 16 M6 12 L10 16 L14 12"/></svg>
-    consumed by
-  </div>
-
-  <!-- Three column output -->
-  <div class="three-col">
-    <div class="section section--sage" style="--i:8">
-      <div class="section-label"><span class="dot"></span> Agent Tools</div>
-      <ul class="node-list">
-        <li><code>search</code> semantic vector search</li>
-        <li><code>clusters</code> browse and filter</li>
-        <li><code>stats</code> aggregate metrics</li>
-      </ul>
-    </div>
-    <div class="section section--plum" style="--i:9">
-      <div class="section-label"><span class="dot"></span> Actions</div>
-      <ul class="node-list">
-        <li>Create tickets from clusters</li>
-        <li>Notify customers on ship</li>
-        <li>Generate release notes</li>
-      </ul>
-    </div>
-    <div class="section section--teal" style="--i:10">
-      <div class="section-label"><span class="dot"></span> Dashboard</div>
-      <ul class="node-list">
-        <li>Metrics overview</li>
-        <li>Feedback stream</li>
-        <li>NL chat interface</li>
-      </ul>
-    </div>
-  </div>
-
-  <!-- Callout — recessed depth for secondary info -->
-  <div class="callout section section--recessed" style="--i:11">
-    <strong>Multi-tenant</strong> &mdash; Each agent gets an isolated database at
-    <code>{agentDir}/intelligence/feedback.db</code> with per-agent config overlay
-    and credential isolation.
-  </div>
-
-</div>
-
-</body>
+  </body>
 </html>

--- a/plugins/visual-explainer/templates/data-table.html
+++ b/plugins/visual-explainer/templates/data-table.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Requirements Audit — Reference Template</title>
-<!--
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Requirements Audit — Reference Template</title>
+    <!--
   Reference template for the visual-explainer skill: data tables.
   Rose/cranberry palette — distinctly different from terracotta (architecture)
   and teal (mermaid) templates so agents absorb variety.
@@ -21,520 +21,572 @@
   - Both light and dark themes via prefers-color-scheme
   - Responsive horizontal scroll wrapper
 -->
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-<style>
-  /* ============ THEME ============ */
-  :root {
-    --font-body: 'Instrument Serif', 'Georgia', serif;
-    --font-mono: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
-    --font-sans: system-ui, -apple-system, sans-serif;
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============ THEME ============ */
+      :root {
+        --font-body: "Instrument Serif", "Georgia", serif;
+        --font-mono: "JetBrains Mono", "SF Mono", Consolas, monospace;
+        --font-sans: system-ui, -apple-system, sans-serif;
 
-    --bg: #fff5f5;
-    --surface: #ffffff;
-    --surface2: #fef0ee;
-    --surface-elevated: #fff8f7;
-    --border: rgba(0, 0, 0, 0.07);
-    --border-bright: rgba(0, 0, 0, 0.14);
-    --text: #1c1917;
-    --text-dim: #78716c;
-    --accent: #be123c;
-    --accent-dim: rgba(190, 18, 60, 0.06);
-    --green: #16a34a;
-    --green-dim: rgba(22, 163, 74, 0.08);
-    --red: #dc2626;
-    --red-dim: rgba(220, 38, 38, 0.08);
-    --orange: #d97706;
-    --orange-dim: rgba(217, 119, 6, 0.08);
-  }
+        --bg: #fff5f5;
+        --surface: #ffffff;
+        --surface2: #fef0ee;
+        --surface-elevated: #fff8f7;
+        --border: rgba(0, 0, 0, 0.07);
+        --border-bright: rgba(0, 0, 0, 0.14);
+        --text: #1c1917;
+        --text-dim: #78716c;
+        --accent: #be123c;
+        --accent-dim: rgba(190, 18, 60, 0.06);
+        --green: #16a34a;
+        --green-dim: rgba(22, 163, 74, 0.08);
+        --red: #dc2626;
+        --red-dim: rgba(220, 38, 38, 0.08);
+        --orange: #d97706;
+        --orange-dim: rgba(217, 119, 6, 0.08);
+      }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #1a0a0a;
-      --surface: #231414;
-      --surface2: #2e1b1b;
-      --surface-elevated: #351f1f;
-      --border: rgba(255, 255, 255, 0.06);
-      --border-bright: rgba(255, 255, 255, 0.12);
-      --text: #fde2e2;
-      --text-dim: #c9a3a3;
-      --accent: #fb7185;
-      --accent-dim: rgba(251, 113, 133, 0.12);
-      --green: #4ade80;
-      --green-dim: rgba(74, 222, 128, 0.1);
-      --red: #f87171;
-      --red-dim: rgba(248, 113, 113, 0.1);
-      --orange: #fbbf24;
-      --orange-dim: rgba(251, 191, 36, 0.1);
-    }
-  }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #1a0a0a;
+          --surface: #231414;
+          --surface2: #2e1b1b;
+          --surface-elevated: #351f1f;
+          --border: rgba(255, 255, 255, 0.06);
+          --border-bright: rgba(255, 255, 255, 0.12);
+          --text: #fde2e2;
+          --text-dim: #c9a3a3;
+          --accent: #fb7185;
+          --accent-dim: rgba(251, 113, 133, 0.12);
+          --green: #4ade80;
+          --green-dim: rgba(74, 222, 128, 0.1);
+          --red: #f87171;
+          --red-dim: rgba(248, 113, 113, 0.1);
+          --orange: #fbbf24;
+          --orange-dim: rgba(251, 191, 36, 0.1);
+        }
+      }
 
-  /* ============ RESET + BASE ============ */
-  * { margin: 0; padding: 0; box-sizing: border-box; }
+      /* ============ RESET + BASE ============ */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  body {
-    background: var(--bg);
-    background-image:
-      radial-gradient(ellipse at 30% 0%, var(--accent-dim) 0%, transparent 50%),
-      radial-gradient(ellipse at 70% 100%, var(--green-dim) 0%, transparent 40%);
-    color: var(--text);
-    font-family: var(--font-sans);
-    padding: 40px;
-    min-height: 100vh;
-  }
+      body {
+        background: var(--bg);
+        background-image:
+          radial-gradient(ellipse at 30% 0%, var(--accent-dim) 0%, transparent 50%),
+          radial-gradient(ellipse at 70% 100%, var(--green-dim) 0%, transparent 40%);
+        color: var(--text);
+        font-family: var(--font-sans);
+        padding: 40px;
+        min-height: 100vh;
+      }
 
-  /* ============ ANIMATION ============ */
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
+      /* ============ ANIMATION ============ */
+      @keyframes fadeUp {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
 
-  .animate {
-    animation: fadeUp 0.35s ease-out both;
-    animation-delay: calc(var(--i, 0) * 0.04s);
-  }
+      .animate {
+        animation: fadeUp 0.35s ease-out both;
+        animation-delay: calc(var(--i, 0) * 0.04s);
+      }
 
-  @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
-      animation-duration: 0.01ms !important;
-      animation-delay: 0ms !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-delay: 0ms !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  /* ============ CONTAINER ============ */
-  .container {
-    max-width: 1000px;
-    margin: 0 auto;
-  }
+      /* ============ CONTAINER ============ */
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
 
-  /* ============ HEADER ============ */
-  h1 {
-    font-family: var(--font-body);
-    font-size: 32px;
-    font-weight: 400;
-    letter-spacing: -0.3px;
-    margin-bottom: 6px;
-  }
+      /* ============ HEADER ============ */
+      h1 {
+        font-family: var(--font-body);
+        font-size: 32px;
+        font-weight: 400;
+        letter-spacing: -0.3px;
+        margin-bottom: 6px;
+      }
 
-  .subtitle {
-    color: var(--text-dim);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    margin-bottom: 32px;
-  }
+      .subtitle {
+        color: var(--text-dim);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        margin-bottom: 32px;
+      }
 
-  /* ============ LEGEND ============ */
-  .legend {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-bottom: 20px;
-  }
+      /* ============ LEGEND ============ */
+      .legend {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 20px;
+      }
 
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-  }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--text-dim);
+      }
 
-  .legend-swatch {
-    width: 10px;
-    height: 10px;
-    border-radius: 3px;
-  }
+      .legend-swatch {
+        width: 10px;
+        height: 10px;
+        border-radius: 3px;
+      }
 
-  /* ============ TABLE WRAPPER ============ */
-  .table-wrap {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    overflow: hidden;
-    margin-bottom: 24px;
-  }
+      /* ============ TABLE WRAPPER ============ */
+      .table-wrap {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        overflow: hidden;
+        margin-bottom: 24px;
+      }
 
-  .table-scroll {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
+      .table-scroll {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
 
-  /* ============ TABLE ============ */
-  .data-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 13px;
-    line-height: 1.55;
-  }
+      /* ============ TABLE ============ */
+      .data-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        line-height: 1.55;
+      }
 
-  /* Header */
-  .data-table thead {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-  }
+      /* Header */
+      .data-table thead {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+      }
 
-  .data-table th {
-    background: var(--surface2);
-    font-family: var(--font-mono);
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
-    color: var(--text-dim);
-    text-align: left;
-    padding: 14px 16px;
-    border-bottom: 2px solid var(--border-bright);
-    white-space: nowrap;
-  }
+      .data-table th {
+        background: var(--surface2);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1.2px;
+        color: var(--text-dim);
+        text-align: left;
+        padding: 14px 16px;
+        border-bottom: 2px solid var(--border-bright);
+        white-space: nowrap;
+      }
 
-  /* Cells */
-  .data-table td {
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--border);
-    vertical-align: top;
-  }
+      /* Cells */
+      .data-table td {
+        padding: 14px 16px;
+        border-bottom: 1px solid var(--border);
+        vertical-align: top;
+      }
 
-  .data-table tbody tr:last-child td {
-    border-bottom: none;
-  }
+      .data-table tbody tr:last-child td {
+        border-bottom: none;
+      }
 
-  /* Wide text column */
-  .data-table .wide {
-    min-width: 220px;
-    max-width: 440px;
-  }
+      /* Wide text column */
+      .data-table .wide {
+        min-width: 220px;
+        max-width: 440px;
+      }
 
-  /* Alternating rows */
-  .data-table tbody tr:nth-child(even) {
-    background: var(--accent-dim);
-  }
+      /* Alternating rows */
+      .data-table tbody tr:nth-child(even) {
+        background: var(--accent-dim);
+      }
 
-  /* Row hover + animation stagger */
-  .data-table tbody tr {
-    transition: background 0.15s ease;
-    animation: fadeUp 0.35s ease-out both;
-    animation-delay: calc(var(--i, 0) * 0.04s);
-  }
+      /* Row hover + animation stagger */
+      .data-table tbody tr {
+        transition: background 0.15s ease;
+        animation: fadeUp 0.35s ease-out both;
+        animation-delay: calc(var(--i, 0) * 0.04s);
+      }
 
-  .data-table tbody tr:hover {
-    background: var(--border);
-  }
+      .data-table tbody tr:hover {
+        background: var(--border);
+      }
 
-  /* Code in cells */
-  .data-table code {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    background: var(--accent-dim);
-    color: var(--accent);
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
+      /* Code in cells */
+      .data-table code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--accent-dim);
+        color: var(--accent);
+        padding: 1px 5px;
+        border-radius: 3px;
+      }
 
-  /* Secondary text */
-  .data-table small {
-    display: block;
-    color: var(--text-dim);
-    font-size: 11px;
-    margin-top: 3px;
-  }
+      /* Secondary text */
+      .data-table small {
+        display: block;
+        color: var(--text-dim);
+        font-size: 11px;
+        margin-top: 3px;
+      }
 
-  /* ============ STATUS BADGES ============ */
-  .status {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    font-family: var(--font-mono);
-    font-size: 10px;
-    font-weight: 600;
-    padding: 3px 10px;
-    border-radius: 6px;
-    white-space: nowrap;
-    letter-spacing: 0.3px;
-  }
+      /* ============ STATUS BADGES ============ */
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        padding: 3px 10px;
+        border-radius: 6px;
+        white-space: nowrap;
+        letter-spacing: 0.3px;
+      }
 
-  .status--match {
-    background: var(--green-dim);
-    color: var(--green);
-  }
+      .status--match {
+        background: var(--green-dim);
+        color: var(--green);
+      }
 
-  .status--gap {
-    background: var(--red-dim);
-    color: var(--red);
-  }
+      .status--gap {
+        background: var(--red-dim);
+        color: var(--red);
+      }
 
-  .status--partial {
-    background: var(--orange-dim);
-    color: var(--orange);
-  }
+      .status--partial {
+        background: var(--orange-dim);
+        color: var(--orange);
+      }
 
-  /* Dot before status text */
-  .status::before {
-    content: '';
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: currentColor;
-  }
+      /* Dot before status text */
+      .status::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
 
-  /* ============ FOOTER ROW ============ */
-  .data-table tfoot td {
-    background: var(--surface2);
-    font-weight: 600;
-    font-family: var(--font-mono);
-    font-size: 12px;
-    border-top: 2px solid var(--border-bright);
-    border-bottom: none;
-    padding: 14px 16px;
-  }
+      /* ============ FOOTER ROW ============ */
+      .data-table tfoot td {
+        background: var(--surface2);
+        font-weight: 600;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        border-top: 2px solid var(--border-bright);
+        border-bottom: none;
+        padding: 14px 16px;
+      }
 
-  /* ============ KPI SUMMARY ============ */
-  .kpi-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 14px;
-    margin-bottom: 20px;
-  }
+      /* ============ KPI SUMMARY ============ */
+      .kpi-row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 14px;
+        margin-bottom: 20px;
+      }
 
-  .kpi-card {
-    background: var(--surface-elevated, var(--surface));
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 18px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  }
+      .kpi-card {
+        background: var(--surface-elevated, var(--surface));
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 18px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+      }
 
-  .kpi-card__value {
-    font-family: var(--font-body);
-    font-size: 32px;
-    font-weight: 400;
-    line-height: 1.1;
-    font-variant-numeric: tabular-nums;
-  }
+      .kpi-card__value {
+        font-family: var(--font-body);
+        font-size: 32px;
+        font-weight: 400;
+        line-height: 1.1;
+        font-variant-numeric: tabular-nums;
+      }
 
-  .kpi-card__value--green { color: var(--green); }
-  .kpi-card__value--red { color: var(--red); }
-  .kpi-card__value--orange { color: var(--orange); }
+      .kpi-card__value--green {
+        color: var(--green);
+      }
+      .kpi-card__value--red {
+        color: var(--red);
+      }
+      .kpi-card__value--orange {
+        color: var(--orange);
+      }
 
-  .kpi-card__label {
-    font-family: var(--font-mono);
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
-    color: var(--text-dim);
-    margin-top: 6px;
-  }
+      .kpi-card__label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1.2px;
+        color: var(--text-dim);
+        margin-top: 6px;
+      }
 
-  /* ============ COLLAPSIBLE ============ */
-  details.collapsible {
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    overflow: hidden;
-  }
+      /* ============ COLLAPSIBLE ============ */
+      details.collapsible {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        overflow: hidden;
+      }
 
-  details.collapsible summary {
-    padding: 14px 20px;
-    background: var(--surface);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    list-style: none;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--text);
-    transition: background 0.15s ease;
-  }
+      details.collapsible summary {
+        padding: 14px 20px;
+        background: var(--surface);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        list-style: none;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--text);
+        transition: background 0.15s ease;
+      }
 
-  details.collapsible summary:hover {
-    background: var(--surface-elevated, var(--surface));
-  }
+      details.collapsible summary:hover {
+        background: var(--surface-elevated, var(--surface));
+      }
 
-  details.collapsible summary::-webkit-details-marker { display: none; }
+      details.collapsible summary::-webkit-details-marker {
+        display: none;
+      }
 
-  details.collapsible summary::before {
-    content: '▸';
-    font-size: 11px;
-    color: var(--text-dim);
-    transition: transform 0.15s ease;
-  }
+      details.collapsible summary::before {
+        content: "▸";
+        font-size: 11px;
+        color: var(--text-dim);
+        transition: transform 0.15s ease;
+      }
 
-  details.collapsible[open] summary::before {
-    transform: rotate(90deg);
-  }
+      details.collapsible[open] summary::before {
+        transform: rotate(90deg);
+      }
 
-  details.collapsible .collapsible__body {
-    padding: 16px 20px;
-    border-top: 1px solid var(--border);
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--text-dim);
-  }
+      details.collapsible .collapsible__body {
+        padding: 16px 20px;
+        border-top: 1px solid var(--border);
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--text-dim);
+      }
 
-  details.collapsible .collapsible__body strong {
-    color: var(--text);
-    font-weight: 600;
-  }
+      details.collapsible .collapsible__body strong {
+        color: var(--text);
+        font-weight: 600;
+      }
 
-  details.collapsible .collapsible__body code {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    background: var(--accent-dim);
-    color: var(--accent);
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
+      details.collapsible .collapsible__body code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--accent-dim);
+        color: var(--accent);
+        padding: 1px 5px;
+        border-radius: 3px;
+      }
 
-  /* ============ RESPONSIVE ============ */
-  @media (max-width: 768px) {
-    body { padding: 16px; }
-    h1 { font-size: 24px; }
-    .data-table th,
-    .data-table td { padding: 10px 12px; }
-  }
-</style>
-</head>
-<body>
+      /* ============ RESPONSIVE ============ */
+      @media (max-width: 768px) {
+        body {
+          padding: 16px;
+        }
+        h1 {
+          font-size: 24px;
+        }
+        .data-table th,
+        .data-table td {
+          padding: 10px 12px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 class="animate" style="--i: 0">Requirements Audit</h1>
+      <p class="subtitle animate" style="--i: 1">
+        victoria's email vs. implementation plan &mdash; point-by-point review
+      </p>
 
-<div class="container">
+      <div class="kpi-row animate" style="--i: 2">
+        <div class="kpi-card">
+          <div class="kpi-card__value">14</div>
+          <div class="kpi-card__label">Items Reviewed</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-card__value kpi-card__value--green">13</div>
+          <div class="kpi-card__label">Match</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-card__value kpi-card__value--red">1</div>
+          <div class="kpi-card__label">Gap</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-card__value" style="color: var(--accent)">93%</div>
+          <div class="kpi-card__label">Coverage</div>
+        </div>
+      </div>
 
-  <h1 class="animate" style="--i:0">Requirements Audit</h1>
-  <p class="subtitle animate" style="--i:1">victoria's email vs. implementation plan &mdash; point-by-point review</p>
+      <div class="legend animate" style="--i: 3">
+        <div class="legend-item">
+          <div class="legend-swatch" style="background: var(--green)"></div>
+          Match
+        </div>
+        <div class="legend-item">
+          <div class="legend-swatch" style="background: var(--red)"></div>
+          Gap
+        </div>
+        <div class="legend-item">
+          <div class="legend-swatch" style="background: var(--orange)"></div>
+          Partial
+        </div>
+      </div>
 
-  <div class="kpi-row animate" style="--i:2">
-    <div class="kpi-card">
-      <div class="kpi-card__value">14</div>
-      <div class="kpi-card__label">Items Reviewed</div>
+      <div class="table-wrap animate" style="--i: 4">
+        <div class="table-scroll">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th class="wide">Request</th>
+                <th class="wide">Plan</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr style="--i: 4">
+                <td class="wide">Template: <code>yoth-special-edition</code> only</td>
+                <td class="wide">Plan scopes everything to this template.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 5">
+                <td class="wide">EOD tomorrow (Friday), Tuesday AM launch</td>
+                <td class="wide">Plan header says same.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 6">
+                <td class="wide">Update BIS button label and pop up text</td>
+                <td class="wide">Button text + modal description configurable via settings.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 7">
+                <td class="wide">Use Stoq's API to trigger events</td>
+                <td class="wide">
+                  Uses <code>openInlineForm</code>, <code>openModal</code>,
+                  <code>removeInlineForm</code>.
+                </td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 8">
+                <td class="wide">Custom button + modal with text settings in buy buttons block</td>
+                <td class="wide">Schema settings in <code>buy_buttons</code> block.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 9">
+                <td class="wide">Default values = current behavior when empty</td>
+                <td class="wide">Blank settings = Stoq default "Notify Me" behavior.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 10">
+                <td class="wide">Only display for OOS variants</td>
+                <td class="wide">DOM-based sold-out detection.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 11">
+                <td class="wide">Exclude products with <code>excludebis</code> tag</td>
+                <td class="wide">Checked in both PDP and PLP Liquid.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 12">
+                <td class="wide"><code>openInlineForm</code> to load Stoq form in modal</td>
+                <td class="wide">PDP modal uses <code>openInlineForm</code>.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 13">
+                <td class="wide">Updated Button Label: "Join the waitlist"</td>
+                <td class="wide">Pre-populated in template JSON.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 14">
+                <td class="wide">
+                  Updated Pop Up Text: "Sign up to be notified when we restock this or other
+                  embroidered styles."
+                </td>
+                <td class="wide"><code>bis_modal_description</code> setting.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 15">
+                <td class="wide">Theme: Huha 2.0 - Giddy Up Collection D2C Launch</td>
+                <td class="wide">Clone ID <code>145580556374</code>.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 16">
+                <td class="wide">Changes made locally</td>
+                <td class="wide">Local dev + theme push.</td>
+                <td><span class="status status--match">Match</span></td>
+              </tr>
+              <tr style="--i: 17">
+                <td class="wide">
+                  Run <code>stoq:restock-modal:submitted</code> when form is submitted
+                </td>
+                <td class="wide">
+                  Not mentioned in plan.
+                  <small
+                    >When using <code>openInlineForm</code> inside a custom modal, unclear if Stoq
+                    fires this event automatically or if manual dispatch is needed.</small
+                  >
+                </td>
+                <td><span class="status status--gap">Gap</span></td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td>14 items reviewed</td>
+                <td></td>
+                <td>13 match &middot; 1 gap</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+
+      <details class="collapsible animate" style="--i: 19">
+        <summary>Gap Analysis Detail</summary>
+        <div class="collapsible__body">
+          <strong>Gap: <code>stoq:restock-modal:submitted</code> event.</strong>
+          Michael explicitly requests firing this event on form submission. The plan uses Stoq's
+          <code>openInlineForm</code> inside a custom modal, but doesn't address whether Stoq
+          dispatches this event automatically in that context. If other integrations (Klaviyo,
+          analytics, theme JS) listen for it, missing it could silently break the submission
+          pipeline. Recommend adding an explicit <code>dispatchEvent</code> call as a safety net.
+        </div>
+      </details>
     </div>
-    <div class="kpi-card">
-      <div class="kpi-card__value kpi-card__value--green">13</div>
-      <div class="kpi-card__label">Match</div>
-    </div>
-    <div class="kpi-card">
-      <div class="kpi-card__value kpi-card__value--red">1</div>
-      <div class="kpi-card__label">Gap</div>
-    </div>
-    <div class="kpi-card">
-      <div class="kpi-card__value" style="color:var(--accent)">93%</div>
-      <div class="kpi-card__label">Coverage</div>
-    </div>
-  </div>
-
-  <div class="legend animate" style="--i:3">
-    <div class="legend-item"><div class="legend-swatch" style="background:var(--green)"></div> Match</div>
-    <div class="legend-item"><div class="legend-swatch" style="background:var(--red)"></div> Gap</div>
-    <div class="legend-item"><div class="legend-swatch" style="background:var(--orange)"></div> Partial</div>
-  </div>
-
-  <div class="table-wrap animate" style="--i:4">
-    <div class="table-scroll">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th class="wide">Request</th>
-            <th class="wide">Plan</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr style="--i:4">
-            <td class="wide">Template: <code>yoth-special-edition</code> only</td>
-            <td class="wide">Plan scopes everything to this template.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:5">
-            <td class="wide">EOD tomorrow (Friday), Tuesday AM launch</td>
-            <td class="wide">Plan header says same.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:6">
-            <td class="wide">Update BIS button label and pop up text</td>
-            <td class="wide">Button text + modal description configurable via settings.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:7">
-            <td class="wide">Use Stoq's API to trigger events</td>
-            <td class="wide">Uses <code>openInlineForm</code>, <code>openModal</code>, <code>removeInlineForm</code>.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:8">
-            <td class="wide">Custom button + modal with text settings in buy buttons block</td>
-            <td class="wide">Schema settings in <code>buy_buttons</code> block.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:9">
-            <td class="wide">Default values = current behavior when empty</td>
-            <td class="wide">Blank settings = Stoq default "Notify Me" behavior.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:10">
-            <td class="wide">Only display for OOS variants</td>
-            <td class="wide">DOM-based sold-out detection.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:11">
-            <td class="wide">Exclude products with <code>excludebis</code> tag</td>
-            <td class="wide">Checked in both PDP and PLP Liquid.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:12">
-            <td class="wide"><code>openInlineForm</code> to load Stoq form in modal</td>
-            <td class="wide">PDP modal uses <code>openInlineForm</code>.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:13">
-            <td class="wide">Updated Button Label: "Join the waitlist"</td>
-            <td class="wide">Pre-populated in template JSON.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:14">
-            <td class="wide">Updated Pop Up Text: "Sign up to be notified when we restock this or other embroidered styles."</td>
-            <td class="wide"><code>bis_modal_description</code> setting.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:15">
-            <td class="wide">Theme: Huha 2.0 - Giddy Up Collection D2C Launch</td>
-            <td class="wide">Clone ID <code>145580556374</code>.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:16">
-            <td class="wide">Changes made locally</td>
-            <td class="wide">Local dev + theme push.</td>
-            <td><span class="status status--match">Match</span></td>
-          </tr>
-          <tr style="--i:17">
-            <td class="wide">Run <code>stoq:restock-modal:submitted</code> when form is submitted</td>
-            <td class="wide">Not mentioned in plan.
-              <small>When using <code>openInlineForm</code> inside a custom modal, unclear if Stoq fires this event automatically or if manual dispatch is needed.</small>
-            </td>
-            <td><span class="status status--gap">Gap</span></td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td>14 items reviewed</td>
-            <td></td>
-            <td>13 match &middot; 1 gap</td>
-          </tr>
-        </tfoot>
-      </table>
-    </div>
-  </div>
-
-  <details class="collapsible animate" style="--i:19">
-    <summary>Gap Analysis Detail</summary>
-    <div class="collapsible__body">
-      <strong>Gap: <code>stoq:restock-modal:submitted</code> event.</strong>
-      Michael explicitly requests firing this event on form submission. The plan uses Stoq's <code>openInlineForm</code> inside a custom modal, but doesn't address whether Stoq dispatches this event automatically in that context. If other integrations (Klaviyo, analytics, theme JS) listen for it, missing it could silently break the submission pipeline. Recommend adding an explicit <code>dispatchEvent</code> call as a safety net.
-    </div>
-  </details>
-
-</div>
-
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the skill docs, prompts, references, and HTML templates with the current formatting and copy updates
- keep the prompt surface aligned with the updated slide, plan-review, diff-review, and fact-check guidance
- preserve all existing relative references used by the skill prompts and docs

## Validation
- `git diff --check`
- HTML parser pass over `templates/*.html`
- prompt/doc relative reference audit