### PR TITLE
feat: add font scale widget for reader-adjustable text sizing

### DIFF
--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -199,6 +199,88 @@ Keep animations purposeful: entrance reveals, hover feedback, and user-initiated
 
 **Tell the user** the file path so they can re-open or share it.
 
+## Font Scale Widget
+
+Every visual-explainer page must include a font scale widget — a small fixed-position control (bottom-right corner) that lets readers adjust text size across 4 presets. This improves accessibility and accommodates different screen sizes and reading preferences.
+
+**How it works:** The widget sets `font-size` on the `<html>` element. All text in the page must use `rem` units so everything scales proportionally. The user's choice persists in `localStorage` and is restored on page load.
+
+**Presets (multiply the base font size):**
+
+| Button | Scale | Effect at 19px base |
+|--------|-------|---------------------|
+| Small A | 0.9× | 17px — compact/data-dense view |
+| Default A | 1× | 19px — standard reading size |
+| Large A | 1.12× | ~21px — comfortable reading |
+| XL A | 1.25× | ~24px — presentation/accessibility |
+
+**Implementation — include in every page:**
+
+HTML (place before main content, outside layout containers):
+```html
+<div class="font-scale" id="fontScale">
+  <button data-scale="0.9" title="Compact">A</button>
+  <button data-scale="1" class="active" title="Default">A</button>
+  <button data-scale="1.12" title="Large">A</button>
+  <button data-scale="1.25" title="Extra Large">A</button>
+</div>
+```
+
+CSS:
+```css
+.font-scale {
+  position: fixed; bottom: 20px; right: 20px; z-index: 300;
+  display: flex; gap: 2px;
+  background: var(--surface); border: 1px solid var(--border-bright);
+  border-radius: 8px; padding: 3px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+}
+.font-scale button {
+  border: none; background: transparent; color: var(--text-dim);
+  font-family: var(--font-body); cursor: pointer; border-radius: 5px;
+  transition: all 0.15s; width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+}
+.font-scale button:nth-child(1) { font-size: 12px; }
+.font-scale button:nth-child(2) { font-size: 15px; }
+.font-scale button:nth-child(3) { font-size: 18px; }
+.font-scale button:nth-child(4) { font-size: 22px; }
+.font-scale button:hover { background: var(--surface2); color: var(--text); }
+.font-scale button.active {
+  background: var(--accent-dim); color: var(--accent); font-weight: 700;
+}
+@media (max-width: 768px) {
+  .font-scale { bottom: 12px; right: 12px; }
+}
+```
+
+JavaScript (place before closing `</body>`):
+```js
+(function() {
+  const widget = document.getElementById('fontScale');
+  const buttons = widget.querySelectorAll('button');
+  const root = document.documentElement;
+  const BASE = 19; // match your base font size
+  const stored = localStorage.getItem('ve-font-scale');
+  if (stored) {
+    root.style.fontSize = (BASE * parseFloat(stored)) + 'px';
+    buttons.forEach(b => b.classList.toggle('active', b.dataset.scale === stored));
+  }
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      root.style.fontSize = (BASE * parseFloat(btn.dataset.scale)) + 'px';
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      localStorage.setItem('ve-font-scale', btn.dataset.scale);
+    });
+  });
+})();
+```
+
+**Important — use `rem` for all font sizes.** Since the widget works by changing the root font size, all text sizing in the page must use `rem` units (not `px`) to scale correctly. The only exceptions are the widget button sizes themselves (12/15/18/22px are fixed so they visually convey the size difference regardless of current scale) and UI chrome elements like zoom controls and badges that should remain constant.
+
+Use your page's accent color variables for the active button state (e.g., `--accent-dim` / `--accent`). The widget inherits the page's `--surface`, `--border-bright`, and `--text-dim` variables so it matches any theme automatically.
+
 ## Diagram Types
 
 ### Architecture / System Diagrams


### PR DESCRIPTION
## Summary

- Adds a **font scale widget** as a required component on every visual-explainer page
- Fixed-position control (bottom-right) with 4 size presets: Compact (0.9x), Default (1x), Large (1.12x), Extra Large (1.25x)
- User preference persists in `localStorage` across page refreshes
- Includes full implementation reference (HTML, CSS, JS) in SKILL.md
- Documents the `rem` unit requirement so all text scales proportionally

## Motivation

Visual explainer pages are information-dense and viewed on a wide range of screens -- from laptops to large monitors to projected displays. Browser zoom works but scales everything including layout. This widget scales only text, preserving the page layout while letting readers pick a comfortable reading size.

It also improves accessibility for users who prefer larger text without requiring them to change system or browser settings.

## What changed

`plugins/visual-explainer/SKILL.md` -- added a new `## Font Scale Widget` section (82 lines) between the Style/Deliver sections and Diagram Types, containing:
- Description of the 4 presets and how they work
- Complete HTML, CSS, and JS snippets for agents to copy
- Guidance on using `rem` units for compatibility
- Note on using page accent colors for the active state

No changes to templates, references, or other files.

## Preview

The widget renders as a small `A A A A` button cluster in the bottom-right corner, styled with the page's own theme variables (`--surface`, `--border-bright`, `--accent-dim`). Each "A" is progressively larger to visually communicate the scale.

Generated with [Claude Code](https://claude.com/claude-code)