### PR TITLE
chore: folder cleanup + gitignore hygiene

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,3 +32,8 @@ Upstream sync is managed via Ai-road-4-You/fork-sync.
 - Keep dependencies updated via Dependabot
 - No hardcoded secrets — use GitHub Secrets or environment variables
 - Follow OWASP Top 10 security practices
+
+## AgentHub Integration
+- Skills: `.agents/skills/` in this repo links to shared AgentHub skills
+- 14 shared agents available (api, architect, cli, deploy, developer, docker, docs, orchestrator, performance, refactor, reviewer, security, tester, troubleshoot)
+- MCP: 12 servers (GitHub, Supabase, Playwright, MongoDB, Notion, HuggingFace, etc.)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Copilot Instructions — visual-explainer
+
+## Project
+
+- **Name**: visual-explainer
+- **Organization**: AiFeatures
+- **Enterprise**: iAiFy
+- **Description**: Agent skill that generates rich HTML pages or slide decks for diagrams, diff reviews, plan audits, data tables, and project recaps
+
+## Fork Status
+
+This is a fork of nicobailon/visual-explainer. Do not contribute back upstream.
+Local customizations are preserved in the main branch.
+Upstream sync is managed via Ai-road-4-You/fork-sync.
+
+## Conventions
+
+- Use kebab-case for file and directory names
+- Use conventional commits (feat:, fix:, chore:, docs:, refactor:, test:)
+- All PRs require review before merge
+- Branch from main, merge back to main
+
+## Shared Infrastructure
+
+- Reusable workflows: Ai-road-4-You/enterprise-ci-cd@v1
+- Composite actions: Ai-road-4-You/github-actions@v1
+- Governance standards: Ai-road-4-You/governance
+
+## Quality Standards
+
+- Run lint and tests before submitting PRs
+- Keep dependencies updated via Dependabot
+- No hardcoded secrets — use GitHub Secrets or environment variables
+- Follow OWASP Top 10 security practices

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    commit-message:
+      prefix: "ci"
+    groups:
+      iaify-shared:
+        patterns:
+          - "Ai-road-4-You/*"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,74 @@
+# === OS ===
 .DS_Store
+Thumbs.db
+Desktop.ini
+
+# === Editor / IDE ===
+*.swp
+*.swo
+*~
+*.bak
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+
+# === Node.js ===
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.npm/
+.yarn/
+
+# === Build output ===
+dist/
+build/
+out/
+.next/
+.nuxt/
+
+# === Logs ===
+*.log
+logs/
+
+# === Environment / secrets ===
+.env
+.env.*
+!.env.example
+
+# === Test / coverage ===
+coverage/
+.nyc_output/
+.c8-output/
+.coverage
+.coverage-tmp/
+
+# === Python ===
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# === Terraform ===
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# === Misc ===
+*.tgz
+*.tar.gz
+*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AI Agent Instructions
+
+## Repository: visual-explainer
+
+- **Organization**: AiFeatures
+- **Enterprise**: iAiFy
+
+## Shared Infrastructure
+
+| Resource | Reference |
+|---|---|
+| Reusable workflows | `Ai-road-4-You/enterprise-ci-cd@v1` |
+| Composite actions | `Ai-road-4-You/github-actions@v1` |
+| Governance docs | `Ai-road-4-You/governance` |
+| Repo templates | `Ai-road-4-You/repo-templates` |
+
+## Conventions
+
+1. Use **conventional commits** (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`)
+2. Create **feature branches** for all changes
+3. Never push directly to `main`
+4. Run tests before submitting PR
+5. Keep dependencies updated via Dependabot
+6. All file names in **kebab-case**
+
+## Quality Gates
+
+Before merging any PR:
+
+- [ ] Lint passes
+- [ ] Tests pass (if test suite exists)
+- [ ] No new security vulnerabilities
+- [ ] PR has meaningful description
+- [ ] Conventional commit messages used
+
+## Agent Guardrails
+
+- Maximum autonomous change: single file or single PR
+- No force pushes
+- No branch deletion without approval
+- No secrets in code or commits
+- All agent changes must be traceable via commit author

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,10 @@ This is a fork of nicobailon/visual-explainer maintained under iAiFy enterprise.
 | Composite actions | Ai-road-4-You/github-actions@v1 |
 | Governance | Ai-road-4-You/governance |
 | Templates | Ai-road-4-You/repo-templates |
+
+## AgentHub
+- Central hub: `~/AgentHub/`
+- Skills: `.agents/skills/` (symlinked to AgentHub shared skills)
+- MCP: 12 servers synced across all agents
+- Agents: 14 shared agents available
+- Hooks: Safety, notification, and logging hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# visual-explainer — Claude Code Context
+
+## Overview
+
+- **Repository**: AiFeatures/visual-explainer
+- **Enterprise**: iAiFy
+- **Description**: Agent skill that generates rich HTML pages or slide decks for diagrams, diff reviews, plan audits, data tables, and project recaps
+
+## Fork Notes
+
+This is a fork of nicobailon/visual-explainer maintained under iAiFy enterprise.
+- Do NOT create PRs back to upstream
+- Local changes live on the main branch
+- Upstream sync managed by Ai-road-4-You/fork-sync
+
+## Conventions
+
+- Conventional commits: feat:, fix:, chore:, docs:
+- Kebab-case file names
+- Branch protection on main — PRs required
+- CODEOWNERS: @AiFeatures/ai-engineering
+
+## Shared Resources
+
+| Asset | Location |
+|---|---|
+| CI/CD workflows | Ai-road-4-You/enterprise-ci-cd@v1 |
+| Composite actions | Ai-road-4-You/github-actions@v1 |
+| Governance | Ai-road-4-You/governance |
+| Templates | Ai-road-4-You/repo-templates |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,59 @@ plugins/
 
 The skill routes to the right approach automatically: Mermaid for flowcharts and diagrams, CSS Grid for architecture overviews, HTML tables for data, Chart.js for dashboards.
 
+## Agent-Hub Integration
+
+This fork is registered as a skill plugin in the iAiFy [AgentHub](https://github.com/AiFeatures) — the shared skill layer used by all 14 agents across the enterprise.
+
+### Manifest
+
+`agenthub-skill.json` at the repo root declares the skill to agent-hub:
+
+```json
+{
+  "name": "visual-explainer",
+  "version": "0.6.3",
+  "type": "output-skill",
+  "capabilities": ["diagram", "diff-review", "plan-review", "data-table", "slide-deck"],
+  "triggers": ["/diagram", "/diff-review", "/plan-review", "/explain"],
+  "output_format": "html",
+  "integration": {
+    "agent-hub": { "register_as": "skill", "category": "visualization" }
+  }
+}
+```
+
+### Integration points
+
+| Point | Detail |
+| --- | --- |
+| Skill entry point | `plugins/visual-explainer/SKILL.md` — loaded automatically when a trigger fires |
+| Commands | `plugins/visual-explainer/commands/*.md` — one file per slash command |
+| Templates | `plugins/visual-explainer/templates/` — reference HTML the agent reads before generating |
+| Output directory | `~/.agent/diagrams/` — shared across all hub agents |
+| Trigger namespace | `/visual-explainer:<command>` in Claude Code; bare `/command` in Pi |
+
+### Install into AgentHub
+
+```bash
+# Symlink the skill into the shared skills directory
+ln -s "$(pwd)/plugins/visual-explainer" ~/AgentHub/.agents/skills/visual-explainer
+
+# Verify the skill is discoverable
+ls ~/AgentHub/.agents/skills/visual-explainer/SKILL.md
+```
+
+After linking, any agent that loads skills from `~/AgentHub/.agents/skills/` will pick up visual-explainer automatically on the next session start.
+
+### Upstream sync
+
+The `upstream-watch` branch tracks `upstream/main` (nicobailon/visual-explainer). Sync is managed by `Ai-road-4-You/fork-sync` — do not raise PRs back to upstream.
+
+```bash
+git fetch upstream
+git log upstream/main..upstream-watch   # see what upstream has changed
+```
+
 ## Limitations
 
 - Requires a browser to view

--- a/agenthub-skill.json
+++ b/agenthub-skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "visual-explainer",
+  "version": "0.6.3",
+  "type": "output-skill",
+  "description": "Generates styled HTML pages for diagrams, diff reviews, plan audits, data tables",
+  "capabilities": ["diagram", "diff-review", "plan-review", "data-table", "slide-deck"],
+  "triggers": ["/diagram", "/diff-review", "/plan-review", "/explain"],
+  "output_format": "html",
+  "themes": ["dark", "light"],
+  "dependencies": {
+    "mermaid": "built-in",
+    "browser": "required"
+  },
+  "integration": {
+    "agent-hub": {
+      "register_as": "skill",
+      "category": "visualization"
+    }
+  }
+}


### PR DESCRIPTION
Part of Wave 1 hardening. Folder structure and tracking cleanup.

## Changes
- **Hardened .gitignore**: Expanded from 1 pattern (.DS_Store only) to comprehensive coverage including node_modules, dist, build, .env*, logs, coverage, Python caches, Terraform state, editor temps, OS junk, and common build artifacts.

## Not needed (repo already clean)
- No tracked files needed untracking
- No folder moves required
- No junk files found on disk