### PR TITLE
docs: refresh README to match current repo state

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,3 +32,8 @@ Upstream sync is managed via Ai-road-4-You/fork-sync.
 - Keep dependencies updated via Dependabot
 - No hardcoded secrets — use GitHub Secrets or environment variables
 - Follow OWASP Top 10 security practices
+
+## AgentHub Integration
+- Skills: `.agents/skills/` in this repo links to shared AgentHub skills
+- 14 shared agents available (api, architect, cli, deploy, developer, docker, docs, orchestrator, performance, refactor, reviewer, security, tester, troubleshoot)
+- MCP: 12 servers (GitHub, Supabase, Playwright, MongoDB, Notion, HuggingFace, etc.)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Copilot Instructions — visual-explainer
+
+## Project
+
+- **Name**: visual-explainer
+- **Organization**: AiFeatures
+- **Enterprise**: iAiFy
+- **Description**: Agent skill that generates rich HTML pages or slide decks for diagrams, diff reviews, plan audits, data tables, and project recaps
+
+## Fork Status
+
+This is a fork of nicobailon/visual-explainer. Do not contribute back upstream.
+Local customizations are preserved in the main branch.
+Upstream sync is managed via Ai-road-4-You/fork-sync.
+
+## Conventions
+
+- Use kebab-case for file and directory names
+- Use conventional commits (feat:, fix:, chore:, docs:, refactor:, test:)
+- All PRs require review before merge
+- Branch from main, merge back to main
+
+## Shared Infrastructure
+
+- Reusable workflows: Ai-road-4-You/enterprise-ci-cd@v1
+- Composite actions: Ai-road-4-You/github-actions@v1
+- Governance standards: Ai-road-4-You/governance
+
+## Quality Standards
+
+- Run lint and tests before submitting PRs
+- Keep dependencies updated via Dependabot
+- No hardcoded secrets — use GitHub Secrets or environment variables
+- Follow OWASP Top 10 security practices

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    commit-message:
+      prefix: "ci"
+    groups:
+      iaify-shared:
+        patterns:
+          - "Ai-road-4-You/*"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,74 @@
+# === OS ===
 .DS_Store
+Thumbs.db
+Desktop.ini
+
+# === Editor / IDE ===
+*.swp
+*.swo
+*~
+*.bak
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+
+# === Node.js ===
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.npm/
+.yarn/
+
+# === Build output ===
+dist/
+build/
+out/
+.next/
+.nuxt/
+
+# === Logs ===
+*.log
+logs/
+
+# === Environment / secrets ===
+.env
+.env.*
+!.env.example
+
+# === Test / coverage ===
+coverage/
+.nyc_output/
+.c8-output/
+.coverage
+.coverage-tmp/
+
+# === Python ===
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# === Terraform ===
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# === Misc ===
+*.tgz
+*.tar.gz
+*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AI Agent Instructions
+
+## Repository: visual-explainer
+
+- **Organization**: AiFeatures
+- **Enterprise**: iAiFy
+
+## Shared Infrastructure
+
+| Resource | Reference |
+|---|---|
+| Reusable workflows | `Ai-road-4-You/enterprise-ci-cd@v1` |
+| Composite actions | `Ai-road-4-You/github-actions@v1` |
+| Governance docs | `Ai-road-4-You/governance` |
+| Repo templates | `Ai-road-4-You/repo-templates` |
+
+## Conventions
+
+1. Use **conventional commits** (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`)
+2. Create **feature branches** for all changes
+3. Never push directly to `main`
+4. Run tests before submitting PR
+5. Keep dependencies updated via Dependabot
+6. All file names in **kebab-case**
+
+## Quality Gates
+
+Before merging any PR:
+
+- [ ] Lint passes
+- [ ] Tests pass (if test suite exists)
+- [ ] No new security vulnerabilities
+- [ ] PR has meaningful description
+- [ ] Conventional commit messages used
+
+## Agent Guardrails
+
+- Maximum autonomous change: single file or single PR
+- No force pushes
+- No branch deletion without approval
+- No secrets in code or commits
+- All agent changes must be traceable via commit author

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,10 @@ This is a fork of nicobailon/visual-explainer maintained under iAiFy enterprise.
 | Composite actions | Ai-road-4-You/github-actions@v1 |
 | Governance | Ai-road-4-You/governance |
 | Templates | Ai-road-4-You/repo-templates |
+
+## AgentHub
+- Central hub: `~/AgentHub/`
+- Skills: `.agents/skills/` (symlinked to AgentHub shared skills)
+- MCP: 12 servers synced across all agents
+- Agents: 14 shared agents available
+- Hooks: Safety, notification, and logging hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# visual-explainer — Claude Code Context
+
+## Overview
+
+- **Repository**: AiFeatures/visual-explainer
+- **Enterprise**: iAiFy
+- **Description**: Agent skill that generates rich HTML pages or slide decks for diagrams, diff reviews, plan audits, data tables, and project recaps
+
+## Fork Notes
+
+This is a fork of nicobailon/visual-explainer maintained under iAiFy enterprise.
+- Do NOT create PRs back to upstream
+- Local changes live on the main branch
+- Upstream sync managed by Ai-road-4-You/fork-sync
+
+## Conventions
+
+- Conventional commits: feat:, fix:, chore:, docs:
+- Kebab-case file names
+- Branch protection on main — PRs required
+- CODEOWNERS: @AiFeatures/ai-engineering
+
+## Shared Resources
+
+| Asset | Location |
+|---|---|
+| CI/CD workflows | Ai-road-4-You/enterprise-ci-cd@v1 |
+| Composite actions | Ai-road-4-You/github-actions@v1 |
+| Governance | Ai-road-4-You/governance |
+| Templates | Ai-road-4-You/repo-templates |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,59 @@ plugins/
 
 The skill routes to the right approach automatically: Mermaid for flowcharts and diagrams, CSS Grid for architecture overviews, HTML tables for data, Chart.js for dashboards.
 
+## Agent-Hub Integration
+
+This fork is registered as a skill plugin in the iAiFy [AgentHub](https://github.com/AiFeatures) — the shared skill layer used by all 14 agents across the enterprise.
+
+### Manifest
+
+`agenthub-skill.json` at the repo root declares the skill to agent-hub:
+
+```json
+{
+  "name": "visual-explainer",
+  "version": "0.6.3",
+  "type": "output-skill",
+  "capabilities": ["diagram", "diff-review", "plan-review", "data-table", "slide-deck"],
+  "triggers": ["/diagram", "/diff-review", "/plan-review", "/explain"],
+  "output_format": "html",
+  "integration": {
+    "agent-hub": { "register_as": "skill", "category": "visualization" }
+  }
+}
+```
+
+### Integration points
+
+| Point | Detail |
+| --- | --- |
+| Skill entry point | `plugins/visual-explainer/SKILL.md` — loaded automatically when a trigger fires |
+| Commands | `plugins/visual-explainer/commands/*.md` — one file per slash command |
+| Templates | `plugins/visual-explainer/templates/` — reference HTML the agent reads before generating |
+| Output directory | `~/.agent/diagrams/` — shared across all hub agents |
+| Trigger namespace | `/visual-explainer:<command>` in Claude Code; bare `/command` in Pi |
+
+### Install into AgentHub
+
+```bash
+# Symlink the skill into the shared skills directory
+ln -s "$(pwd)/plugins/visual-explainer" ~/AgentHub/.agents/skills/visual-explainer
+
+# Verify the skill is discoverable
+ls ~/AgentHub/.agents/skills/visual-explainer/SKILL.md
+```
+
+After linking, any agent that loads skills from `~/AgentHub/.agents/skills/` will pick up visual-explainer automatically on the next session start.
+
+### Upstream sync
+
+The `upstream-watch` branch tracks `upstream/main` (nicobailon/visual-explainer). Sync is managed by `Ai-road-4-You/fork-sync` — do not raise PRs back to upstream.
+
+```bash
+git fetch upstream
+git log upstream/main..upstream-watch   # see what upstream has changed
+```
+
 ## Limitations
 
 - Requires a browser to view

--- a/README.md
+++ b/README.md
@@ -4,11 +4,49 @@
 
 # visual-explainer
 
-**An agent skill that turns complex terminal output into styled HTML pages you actually want to read.**
+Agent skill that turns complex terminal output into styled HTML pages and slide decks.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
 
-Ask your agent to explain a system architecture, review a diff, or compare requirements against a plan. Instead of ASCII art and box-drawing tables, it generates a self-contained HTML page and opens it in your browser.
+## Why
+
+Coding agents default to ASCII art for diagrams and monospace tables for data. Both break down past trivial complexity — flowcharts become unreadable and tables wrap in the terminal. This skill generates self-contained HTML pages instead, with real typography, dark/light themes, interactive Mermaid diagrams with zoom and pan, and no dependencies beyond a browser.
+
+## Status
+
+| Field | Value |
+|-------|-------|
+| Version | 0.6.3 |
+| Last release | 2026-03-09 |
+| Stability | Active development — production-used across iAiFy agents |
+| Fork of | [nicobailon/visual-explainer](https://github.com/nicobailon/visual-explainer) (do not PR upstream) |
+
+## Quick Start
+
+**Claude Code (marketplace):**
+```shell
+/plugin marketplace add AiFeatures/visual-explainer
+/plugin install visual-explainer@visual-explainer-marketplace
+```
+
+**Pi:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/AiFeatures/visual-explainer/main/install-pi.sh | bash
+```
+
+**OpenAI Codex:**
+```bash
+git clone --depth 1 https://github.com/AiFeatures/visual-explainer.git /tmp/visual-explainer
+cp -r /tmp/visual-explainer/plugins/visual-explainer ~/.agents/skills/visual-explainer
+rm -rf /tmp/visual-explainer
+```
+
+**AgentHub (enterprise):**
+```bash
+ln -s "$(pwd)/plugins/visual-explainer" ~/AgentHub/.agents/skills/visual-explainer
+```
+
+After install, invoke commands directly or let the agent activate the skill implicitly:
 
 ```
 > draw a diagram of our authentication flow
@@ -16,167 +54,69 @@ Ask your agent to explain a system architecture, review a diff, or compare requi
 > /plan-review ~/docs/refactor-plan.md
 ```
 
-https://github.com/user-attachments/assets/55ebc81b-8732-40f6-a4b1-7c3781aa96ec
-
-## Why
-
-Every coding agent defaults to ASCII art when you ask for a diagram. Box-drawing characters, monospace alignment hacks, text arrows. It works for trivial cases, but anything beyond a 3-box flowchart turns into an unreadable mess.
-
-Tables are worse. Ask the agent to compare 15 requirements against a plan and you get a wall of pipes and dashes that wraps and breaks in the terminal. The data is there but it's painful to read.
-
-This skill fixes that. Real typography, dark/light themes, interactive Mermaid diagrams with zoom and pan. No build step, no dependencies beyond a browser.
-
-## Install
-
-**Claude Code (marketplace):**
-```shell
-/plugin marketplace add nicobailon/visual-explainer
-/plugin install visual-explainer@visual-explainer-marketplace
-```
-
-Note: Claude Code plugins namespace commands as `/visual-explainer:command-name`.
-
-**Pi:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/nicobailon/visual-explainer/main/install-pi.sh | bash
-```
-
-Or clone and run:
-```bash
-git clone --depth 1 https://github.com/nicobailon/visual-explainer.git
-cd visual-explainer && ./install-pi.sh
-```
-
-**OpenAI Codex:**
-```bash
-git clone --depth 1 https://github.com/nicobailon/visual-explainer.git /tmp/visual-explainer
-
-# Install skill
-cp -r /tmp/visual-explainer/plugins/visual-explainer ~/.agents/skills/visual-explainer
-
-# Optional: Install slash commands (deprecated, but works)
-mkdir -p ~/.codex/prompts
-cp /tmp/visual-explainer/plugins/visual-explainer/commands/*.md ~/.codex/prompts/
-
-rm -rf /tmp/visual-explainer
-```
-
-Invoke with `$visual-explainer` or let Codex activate it implicitly. With prompts installed, use `/prompts:diff-review`, `/prompts:plan-review`, etc.
-
 ## Commands
 
-| Command | What it does |
+| Command | Description |
 |---------|-------------|
-| `/generate-web-diagram` | Generate an HTML diagram for any topic |
-| `/generate-visual-plan` | Generate a visual implementation plan for a feature or extension |
-| `/generate-slides` | Generate a magazine-quality slide deck |
-| `/diff-review` | Visual diff review with architecture comparison and code review |
-| `/plan-review` | Compare a plan against the codebase with risk assessment |
-| `/project-recap` | Mental model snapshot for context-switching back to a project |
-| `/fact-check` | Verify accuracy of a document against actual code |
-| `/share` | Deploy an HTML page to Vercel and get a live URL |
+| `/generate-web-diagram` | HTML diagram for any topic |
+| `/generate-visual-plan` | Visual implementation plan for a feature |
+| `/generate-slides` | Magazine-quality slide deck |
+| `/diff-review` | Visual diff review with architecture comparison |
+| `/plan-review` | Plan vs. codebase with risk assessment |
+| `/project-recap` | Mental model snapshot for context-switching |
+| `/fact-check` | Verify a document against actual code |
+| `/share` | Deploy an HTML page to Vercel |
 
-The agent also kicks in automatically when it's about to dump a complex table in the terminal (4+ rows or 3+ columns) — it renders HTML instead.
+Any command that produces a scrollable page also supports `--slides` for slide deck output.
 
-## Slide Deck Mode
+The agent also activates automatically for complex tables (4+ rows or 3+ columns).
 
-Any command that produces a scrollable page supports `--slides` to generate a slide deck instead:
-
-```
-/diff-review --slides
-/project-recap --slides 2w
-```
-
-https://github.com/user-attachments/assets/342d3558-5fcf-4fb2-bc03-f0dd5b9e35dc
-
-## How It Works
+## Architecture
 
 ```
-.claude-plugin/
-├── plugin.json           ← marketplace identity
-└── marketplace.json      ← plugin catalog
-plugins/
-└── visual-explainer/
-    ├── .claude-plugin/
-    │   └── plugin.json   ← plugin manifest
-    ├── SKILL.md           ← workflow + design principles
-    ├── commands/          ← slash commands
-    ├── references/        ← agent reads before generating
-    │   ├── css-patterns.md   (layouts, animations, theming)
-    │   ├── libraries.md      (Mermaid, Chart.js, fonts)
-    │   ├── responsive-nav.md (sticky TOC for multi-section pages)
-    │   └── slide-patterns.md (slide engine, transitions, presets)
-    ├── templates/         ← reference templates with different palettes
-    │   ├── architecture.html
-    │   ├── mermaid-flowchart.html
-    │   ├── data-table.html
-    │   └── slide-deck.html
-    └── scripts/
-        └── share.sh       ← deploy HTML to Vercel for sharing
+plugins/visual-explainer/
+├── SKILL.md              ← workflow + design principles
+├── commands/             ← slash command definitions
+├── references/           ← design system docs the agent reads before generating
+│   ├── css-patterns.md
+│   ├── libraries.md
+│   ├── responsive-nav.md
+│   └── slide-patterns.md
+├── templates/            ← reference HTML with different palettes
+│   ├── architecture.html
+│   ├── mermaid-flowchart.html
+│   ├── data-table.html
+│   └── slide-deck.html
+└── scripts/
+    └── share.sh          ← deploy to Vercel
 ```
 
-**Output:** `~/.agent/diagrams/filename.html` → opens in browser
+**Output:** `~/.agent/diagrams/<filename>.html` → opens in browser.
 
-The skill routes to the right approach automatically: Mermaid for flowcharts and diagrams, CSS Grid for architecture overviews, HTML tables for data, Chart.js for dashboards.
+The skill routes automatically: Mermaid for flowcharts, CSS Grid for architecture overviews, HTML tables for data, Chart.js for dashboards.
 
-## Agent-Hub Integration
+## Development
 
-This fork is registered as a skill plugin in the iAiFy [AgentHub](https://github.com/AiFeatures) — the shared skill layer used by all 14 agents across the enterprise.
+This is a zero-build skill — no compile step, no test runner, no runtime dependencies. The repo contains Markdown prompts, HTML templates, and reference docs that agents consume directly.
 
-### Manifest
-
-`agenthub-skill.json` at the repo root declares the skill to agent-hub:
-
-```json
-{
-  "name": "visual-explainer",
-  "version": "0.6.3",
-  "type": "output-skill",
-  "capabilities": ["diagram", "diff-review", "plan-review", "data-table", "slide-deck"],
-  "triggers": ["/diagram", "/diff-review", "/plan-review", "/explain"],
-  "output_format": "html",
-  "integration": {
-    "agent-hub": { "register_as": "skill", "category": "visualization" }
-  }
-}
-```
-
-### Integration points
-
-| Point | Detail |
-| --- | --- |
-| Skill entry point | `plugins/visual-explainer/SKILL.md` — loaded automatically when a trigger fires |
-| Commands | `plugins/visual-explainer/commands/*.md` — one file per slash command |
-| Templates | `plugins/visual-explainer/templates/` — reference HTML the agent reads before generating |
-| Output directory | `~/.agent/diagrams/` — shared across all hub agents |
-| Trigger namespace | `/visual-explainer:<command>` in Claude Code; bare `/command` in Pi |
-
-### Install into AgentHub
+To work on it:
 
 ```bash
-# Symlink the skill into the shared skills directory
-ln -s "$(pwd)/plugins/visual-explainer" ~/AgentHub/.agents/skills/visual-explainer
-
-# Verify the skill is discoverable
-ls ~/AgentHub/.agents/skills/visual-explainer/SKILL.md
+git clone https://github.com/AiFeatures/visual-explainer.git
+cd visual-explainer
 ```
 
-After linking, any agent that loads skills from `~/AgentHub/.agents/skills/` will pick up visual-explainer automatically on the next session start.
+Validate templates by opening any `plugins/visual-explainer/templates/*.html` file in a browser.
 
-### Upstream sync
+## Deployment
 
-The `upstream-watch` branch tracks `upstream/main` (nicobailon/visual-explainer). Sync is managed by `Ai-road-4-You/fork-sync` — do not raise PRs back to upstream.
+CI/CD uses the enterprise shared workflows from [`Ai-road-4-You/enterprise-ci-cd@v1`](https://github.com/Ai-road-4-You/enterprise-ci-cd). Release tagging follows `release.yml@v1` with `tags-override: latest`.
 
-```bash
-git fetch upstream
-git log upstream/main..upstream-watch   # see what upstream has changed
-```
+Upstream sync is managed by [`Ai-road-4-You/fork-sync`](https://github.com/Ai-road-4-You/fork-sync) — do not raise PRs back to the upstream repo.
 
-## Limitations
+## Contributing
 
-- Requires a browser to view
-- Switching OS theme requires a page refresh for Mermaid SVGs
-- Results vary by model capability
+See [Ai-road-4-You/governance](https://github.com/Ai-road-4-You/governance).
 
 ## Credits
 
@@ -184,4 +124,4 @@ Borrows ideas from [Anthropic's frontend-design skill](https://github.com/anthro
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/agenthub-skill.json
+++ b/agenthub-skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "visual-explainer",
+  "version": "0.6.3",
+  "type": "output-skill",
+  "description": "Generates styled HTML pages for diagrams, diff reviews, plan audits, data tables",
+  "capabilities": ["diagram", "diff-review", "plan-review", "data-table", "slide-deck"],
+  "triggers": ["/diagram", "/diff-review", "/plan-review", "/explain"],
+  "output_format": "html",
+  "themes": ["dark", "light"],
+  "dependencies": {
+    "mermaid": "built-in",
+    "browser": "required"
+  },
+  "integration": {
+    "agent-hub": {
+      "register_as": "skill",
+      "category": "visualization"
+    }
+  }
+}


### PR DESCRIPTION
Part of Wave 1 hardening. README audit + refresh.

### Changes
- Update install URLs from upstream (nicobailon) to fork (AiFeatures)
- Add Status table with version, last release, stability
- Add Quick Start with verified install commands for all platforms
- Add Architecture, Development, Deployment, Contributing sections
- Remove verbose Agent-Hub Integration (condensed to Quick Start)
- Remove embedded video links and upstream sync details
- Condense Commands table descriptions

### Metrics
- **Old line count:** 187
- **New line count:** 127