### PR TITLE
fix(share): use Vercel CLI directly instead of deprecated vercel-deploy skill

### DIFF
--- a/plugins/visual-explainer/commands/share-page.md
+++ b/plugins/visual-explainer/commands/share-page.md
@@ -3,7 +3,7 @@ description: Deploy a generated visual-explainer HTML page and return a live Ver
 ---
 # Share Visual Explainer Page
 
-Share a visual explainer HTML file instantly via Vercel. Returns a live URL with no authentication required when a Pi-compatible `vercel-deploy` skill is installed.
+Share a visual explainer HTML file via Vercel. Returns a live URL deployed under your Vercel account using the Vercel CLI.
 
 ## Usage
 
@@ -22,47 +22,44 @@ Share a visual explainer HTML file instantly via Vercel. Returns a live URL with
 
 ## How It Works
 
-1. Finds the `visual-explainer` skill directory for the current harness
-2. Copies your HTML file to a temp directory as `index.html`
-3. Deploys via the Pi-compatible `vercel-deploy` skill
-4. Returns a live URL immediately
+1. Copies your HTML file to a temp directory as `index.html`
+2. Runs `vercel deploy --yes` from that directory
+3. Returns the live preview URL
 
 ## Requirements
 
-- **vercel-deploy skill** - Required for deployment. In Pi, install with: `pi install npm:vercel-deploy`
+- **Vercel CLI** — install with `npm i -g vercel` (or `bun add -g vercel`)
+- **Authenticated session** — run `vercel login` once
 
-No Vercel account, Cloudflare account, or API keys needed. The deployment is "claimable" — you can transfer it to your Vercel account later if you want.
+Deployments land in your own Vercel account, so no claim step is needed.
 
 ## Script Location
 
 Resolve the script from the installed skill directory, then run it with the HTML file path:
 
 ```bash
-bash ~/.pi/agent/skills/visual-explainer/scripts/share.sh <file>
+bash ~/.claude/plugins/cache/visual-explainer-marketplace/visual-explainer/<version>/scripts/share.sh <file>
 ```
 
-If the skill is installed somewhere else, use that install path instead. Common locations include `~/.codex/skills/visual-explainer/scripts/share.sh`, `~/.config/opencode/skill/visual-explainer/scripts/share.sh`, or `./plugins/visual-explainer/scripts/share.sh` from a repository checkout.
-
-The script currently looks for the Pi-compatible `vercel-deploy` script in the standard Pi skill locations. Other harnesses can generate and open HTML normally, but sharing requires that dependency to be available in a compatible location.
+Common alternatives include `~/.codex/skills/visual-explainer/scripts/share.sh`, `~/.config/opencode/skill/visual-explainer/scripts/share.sh`, or `./plugins/visual-explainer/scripts/share.sh` from a repository checkout.
 
 ## Output
 
 ```
-Sharing my-diagram.html...
+Sharing my-diagram.html via Vercel...
 
 ✓ Shared successfully!
 
-Live URL:  https://skill-deploy-abc123.vercel.app
-Claim URL: https://vercel.com/claim-deployment?code=...
+Live URL:  https://visual-explainer-abc123.vercel.app
 ```
 
 The script also outputs JSON for programmatic use:
 ```json
-{"previewUrl":"https://...","claimUrl":"https://...","deploymentId":"...","projectId":"..."}
+{"previewUrl":"https://..."}
 ```
 
 ## Notes
 
 - Deployments are **public** — anyone with the URL can view
-- Preview deployments have a configurable retention period (default: 30 days)
 - Each share creates a new deployment with a unique URL
+- Deployments live under your Vercel account; manage retention via the Vercel dashboard

--- a/plugins/visual-explainer/scripts/share.sh
+++ b/plugins/visual-explainer/scripts/share.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Share Visual Explainer HTML via Vercel
+# Share Visual Explainer HTML via Vercel CLI
 # Usage: ./share.sh <html-file>
-# Returns: Live URL instantly (no auth required)
+# Requires: vercel CLI on PATH, authenticated session (`vercel login`)
 
 set -e
 
@@ -24,49 +24,43 @@ if [ ! -f "$HTML_FILE" ]; then
     exit 1
 fi
 
-# Find vercel-deploy skill
-VERCEL_SCRIPT=""
-for dir in ~/.pi/agent/skills/vercel-deploy/scripts /mnt/skills/user/vercel-deploy/scripts; do
-    if [ -f "$dir/deploy.sh" ]; then
-        VERCEL_SCRIPT="$dir/deploy.sh"
-        break
-    fi
-done
-
-if [ -z "$VERCEL_SCRIPT" ]; then
-    echo -e "${RED}Error: vercel-deploy skill not found${NC}" >&2
-    echo "Install it with: pi install npm:vercel-deploy" >&2
+if ! command -v vercel >/dev/null 2>&1; then
+    echo -e "${RED}Error: vercel CLI not found on PATH${NC}" >&2
+    echo "Install: npm i -g vercel    (or: bun add -g vercel)" >&2
     exit 1
 fi
 
-# Create temp directory with index.html
+if ! vercel whoami >/dev/null 2>&1; then
+    echo -e "${RED}Error: not authenticated with Vercel${NC}" >&2
+    echo "Run: vercel login" >&2
+    exit 1
+fi
+
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
-# Copy file as index.html (Vercel serves index.html at root)
-cp "$HTML_FILE" "$TEMP_DIR/index.html"
+# Use a stable subdir name so Vercel derives a clean project name from it
+DEPLOY_DIR="$TEMP_DIR/visual-explainer"
+mkdir -p "$DEPLOY_DIR"
+cp "$HTML_FILE" "$DEPLOY_DIR/index.html"
 
-echo -e "${CYAN}Sharing $(basename "$HTML_FILE")...${NC}" >&2
+echo -e "${CYAN}Sharing $(basename "$HTML_FILE") via Vercel...${NC}" >&2
 
-# Deploy via vercel-deploy skill
-# Temporarily disable errexit to capture deployment errors
 set +e
-RESULT=$(bash "$VERCEL_SCRIPT" "$TEMP_DIR" 2>&1)
+RESULT=$(cd "$DEPLOY_DIR" && vercel deploy --yes 2>&1)
 DEPLOY_EXIT=$?
 set -e
 
 if [ $DEPLOY_EXIT -ne 0 ]; then
-    echo -e "${RED}Error: Deployment failed${NC}" >&2
+    echo -e "${RED}Error: vercel deploy failed${NC}" >&2
     echo "$RESULT" >&2
     exit 1
 fi
 
-# Extract preview URL
-PREVIEW_URL=$(echo "$RESULT" | grep -oE 'https://[^"]+\.vercel\.app' | head -1)
-CLAIM_URL=$(echo "$RESULT" | grep -oE 'https://vercel\.com/claim-deployment[^"]+' | head -1)
+PREVIEW_URL=$(echo "$RESULT" | grep -oE 'https://[a-zA-Z0-9.-]+\.vercel\.app' | head -1)
 
 if [ -z "$PREVIEW_URL" ]; then
-    echo -e "${RED}Error: Deployment failed${NC}" >&2
+    echo -e "${RED}Error: could not parse preview URL from vercel output${NC}" >&2
     echo "$RESULT" >&2
     exit 1
 fi
@@ -75,8 +69,7 @@ echo "" >&2
 echo -e "${GREEN}✓ Shared successfully!${NC}" >&2
 echo "" >&2
 echo -e "${GREEN}Live URL:  ${PREVIEW_URL}${NC}" >&2
-echo -e "${CYAN}Claim URL: ${CLAIM_URL}${NC}" >&2
 echo "" >&2
 
-# Output JSON for programmatic use (extract from vercel-deploy output)
-echo "$RESULT" | grep -E '^\{' | head -1
+# JSON for programmatic callers
+printf '{"previewUrl":"%s"}\n' "$PREVIEW_URL"


### PR DESCRIPTION
## Problem

The `vercel-deploy` skill that `share.sh` depends on posts to `https://codex-deploy-skills.vercel.sh/api/deploy`, which no longer auto-deploys. The endpoint now returns HTTP 200 with text instructions saying *"the recommended way to deploy is now via the Vercel CLI."*

Because the response no longer contains a `previewUrl` field, `share.sh`'s parser fails and `/share-page` is broken.

## Fix

Replace the `vercel-deploy` skill indirection with a direct `vercel deploy --yes` invocation.

- Precondition checks: `vercel` CLI on PATH and `vercel whoami` succeeds — clear errors otherwise
- Copy HTML into a stable subdir (`visual-explainer/`) so Vercel derives a clean project name
- Parse the `.vercel.app` URL from CLI output

Deployments now land in the user's own Vercel account, so the claim-deployment step is no longer needed (and is removed from the script + docs).

## Tradeoffs

- New requirements: users need `npm i -g vercel` and `vercel login` once. Documented in `commands/share-page.md`.
- No more anonymous claimable deployments — but the previous flow was non-functional, so this is a strict improvement.

## Test

Smoke tested locally on macOS / Vercel CLI 53.0.1 against a small HTML file: deploys cleanly and returns a working preview URL.