### PR TITLE
fix: load mono font at all weights the CSS renders (avoid faux-bold)

### DIFF
--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -149,6 +149,8 @@ Apply these principles to every diagram:
 
 Load via `<link>` in `<head>`. Include a system font fallback in the `font-family` stack for offline resilience.
 
+**Load every weight you use — mono included.** These patterns set the mono font at `400`/`500`/`600`/`700` (uppercase labels, table headers, status pills, the `.opt` cell), so request `wght@400;500;600;700` for the mono family too, not just the body. A weight the CSS uses but the `<link>` omits gets faux-bolded by the browser — smeared, mangled glyphs, ugliest on monospace. (Fragment Mono and Space Mono ship limited weights; pair them only with CSS that stays within what they offer.)
+
 **Color tells a story.** Use CSS custom properties for the full palette. Define at minimum: `--bg`, `--surface`, `--border`, `--text`, `--text-dim`, and 3-5 accent colors. Each accent should have a full and a dim variant (for backgrounds). Name variables semantically when possible (`--pipeline-step` not `--blue-3`). Support both themes.
 
 **Forbidden accent colors:** `#8b5cf6` `#7c3aed` `#a78bfa` (indigo/violet), `#d946ef` (fuchsia), the cyan-magenta-pink combination. These are Tailwind defaults that signal zero design intent.

--- a/plugins/visual-explainer/references/css-patterns.md
+++ b/plugins/visual-explainer/references/css-patterns.md
@@ -9,7 +9,7 @@ Always define both light and dark palettes via custom properties. Start with whi
 ```css
 :root {
   --font-body: 'Outfit', system-ui, sans-serif;
-  --font-mono: 'Space Mono', 'SF Mono', Consolas, monospace;
+  --font-mono: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
 
   --bg: #f8f9fa;
   --surface: #ffffff;

--- a/plugins/visual-explainer/references/libraries.md
+++ b/plugins/visual-explainer/references/libraries.md
@@ -567,16 +567,18 @@ Always load with `display=swap` for fast rendering. Pick a distinctive pairing �
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 ```
 
 Define as CSS variables for easy reference:
 ```css
 :root {
-  --font-body: 'Outfit', system-ui, sans-serif;
-  --font-mono: 'Space Mono', 'SF Mono', Consolas, monospace;
+  --font-body: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SF Mono', Consolas, monospace;
 }
 ```
+
+**Load every weight you render — for the mono font too.** The component CSS uses mono at `400`/`500`/`600`/`700` (labels, table headers, status pills, the `.opt` cell), so both families above carry `wght@400;500;600;700`. A weight used in CSS but missing from the `<link>` is synthesized as faux-bold by the browser — mangled, smeared glyphs, worst on monospace. Never load the mono with fewer weights than the body.
 
 **Font pairings** (rotate — never use the same pairing twice in a row):
 
@@ -597,6 +599,8 @@ Define as CSS variables for easy reference:
 | Playfair Display | Roboto Mono | Elegant contrast | Executive summaries |
 
 The first 5 pairings are recommended for most use cases. Vary across consecutive diagrams.
+
+**Weight-limited monos:** Fragment Mono ships `400` only; Space Mono only `400`/`700`. They have no `500`/`600`, so the browser fakes those weights — pick them only for pages whose mono text stays at the weights they offer, otherwise prefer a full-range mono (Fira Code, JetBrains Mono, IBM Plex Mono, Azeret Mono, Geist Mono, Roboto Mono).
 
 ### Typography by Content Voice
 


### PR DESCRIPTION
## Problem

The typography guidance tells authors to pick a font pairing and load it via `<link>`, but never specifies *which weights* to request. The component patterns throughout the skill use the **mono** font at `400`/`500`/`600`/`700` (uppercase labels, table headers, status pills, the `.opt` cell) — yet several canonical examples ship a weight-limited mono:

- `references/libraries.md` loaded Space Mono at only `400;700`.
- `references/css-patterns.md`'s copy-paste "Theme Setup" block defaulted `--font-mono` to Space Mono (`400`/`700` only), while the same file uses `var(--font-mono)` at `font-weight: 600` (e.g. the code-file header label).

When a weight is used in CSS but absent from the `<link>`, the browser synthesizes it as **faux-bold**: smeared, lopsided glyphs — worst on monospace.

Real-world symptom: a generated page loaded `Fira Code:wght@400;500` but used it at `font-weight: 600`/`700`, rendering mangled label text.

## Changes

- **`SKILL.md`** — add a *"load every weight you use — mono included"* rule next to the pairing guidance, with the faux-bold warning.
- **`references/libraries.md`**
  - Make the canonical import example model the rule (symmetric full weights, swapping the weight-limited Space Mono illustration for IBM Plex Sans/Mono, which ship `400;500;600;700`).
  - Add the same rule below the example.
  - Flag weight-limited monos (Fragment Mono = `400` only, Space Mono = `400`/`700`) in the pairing table.
- **`references/css-patterns.md`** — switch the starter theme's default `--font-mono` from Space Mono to JetBrains Mono (full weight range), so the most-copied reference doesn't ship the faux-bold bug out of the box.

## Notes

- Docs/guidance only — **no template behavior changes**. The bundled templates were already self-consistent (each loads every weight it uses, including `mermaid-flowchart.html`, which renders Fragment Mono only at `400`).
- Space Mono and Fragment Mono remain **valid listed pairings** — they're just no longer defaults, and the new caveat steers them toward pages that stay within the weights they offer.
- Keeps the heavy-mono aesthetic intact by loading the weights the CSS renders, rather than weakening the CSS.
