### PR TITLE
Compress visual-explainer prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Added one Pi extension tool, `visual_explainer`, with `prepare` for permission-aware visual explanation planning and optional subagent scouting, plus `render` for writing and opening generated HTML pages while keeping `/generate-web-diagram` as a prompt template.
 
+### Changed
+- Compressed the visual-explainer skill and command prompts from 10,824 words to 2,131 words, an 80%+ reduction in prompt tokens, while preserving the hard rendering, Mermaid, table, slide, and review-section requirements.
+
 ## [0.7.1] - 2026-04-27
 
 ### Compatibility

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: visual-explainer
-description: Generate beautiful, self-contained HTML pages that visually explain systems, code changes, plans, and data. Use when the user asks for a diagram, architecture overview, diff review, plan review, project recap, comparison table, or any visual explanation of technical concepts. Also use proactively when you are about to render a complex ASCII table (4+ rows or 3+ columns) — present it as a styled HTML page instead.
 license: MIT
 compatibility: Requires a browser to view generated HTML files. Optional surf-cli for AI image generation.
 metadata:
@@ -10,430 +9,94 @@ metadata:
 
 # Visual Explainer
 
-Generate self-contained HTML files for technical diagrams, visualizations, and data tables. Always open the result in the browser. Never fall back to ASCII art when this skill is loaded.
-
-**Proactive table rendering.** When you're about to present tabular data as an ASCII box-drawing table in the terminal (comparisons, audits, feature matrices, status reports, any structured rows/columns), generate an HTML page instead. The threshold: if the table has 4+ rows or 3+ columns, it belongs in the browser. Don't wait for the user to ask — render it as HTML automatically and tell them the file path. You can still include a brief text summary in the chat, but the table itself should be the HTML page.
-
-## Available Commands
-
-Detailed prompt templates live in `./commands/`. In Pi, these are slash commands (`/diff-review`). Pi package installs also provide the `visual_explainer` tool for planning visual explanations with `action: "prepare"` and writing complete HTML to `~/.agent/diagrams/` with `action: "render"`. In Claude Code, commands are namespaced (`/visual-explainer:diff-review`). In Codex, use `/prompts:diff-review` (if installed to `~/.codex/prompts/`) or invoke `$visual-explainer` and describe the workflow.
-
-| Command | What it does |
-|---------|-------------|
-| `generate-web-diagram` | Generate an HTML diagram for any topic |
-| `generate-visual-plan` | Generate a visual implementation plan for a feature |
-| `generate-slides` | Generate a magazine-quality slide deck |
-| `diff-review` | Visual diff review with architecture comparison and code review |
-| `plan-review` | Compare a plan against the codebase with risk assessment |
-| `project-recap` | Mental model snapshot for context-switching back to a project |
-| `fact-check` | Verify accuracy of a document against actual code |
-
-## Workflow
-
-### 1. Think (5 seconds, not 5 minutes)
-
-Before writing HTML, commit to a direction. Don't default to "dark theme with blue accents" every time.
-
-**Visual is always default.** Even essays, blog posts, and articles get visual treatment — extract structure into cards, diagrams, grids, tables.
-
-Prose patterns (lead paragraphs, pull quotes, callout boxes) are **accent elements** within visual pages, not a separate mode. Use them to highlight key points or provide breathing room, but the page structure remains visual.
-
-For prose accents, see "Prose Page Elements" in `./references/css-patterns.md`. For everything else, use the standard freeform approach with aesthetic directions below.
-
-**Who is looking?** A developer understanding a system? A PM seeing the big picture? A team reviewing a proposal? This shapes information density and visual complexity.
-
-**What type of content?** Architecture, flowchart, sequence, data flow, schema/ER, state machine, mind map, class diagram, C4 architecture, data table, timeline, dashboard, or prose-first page. Each has distinct layout needs and rendering approaches (see Diagram Types below).
-
-**What aesthetic?** Pick one and commit. The constrained aesthetics (Blueprint, Editorial, Paper/ink) are safer — they have specific requirements that prevent generic output. The flexible ones (IDE-inspired) require more discipline.
-
-**Constrained aesthetics (prefer these):**
-- Blueprint (technical drawing feel, subtle grid background, deep slate/blue palette, monospace labels, precise borders) — see `websocket-implementation-plan.html` for reference
-- Editorial (serif headlines like Instrument Serif or Crimson Pro, generous whitespace, muted earth tones or deep navy + gold)
-- Paper/ink (warm cream `#faf7f5` background, terracotta/sage accents, informal feel)
-- Monochrome terminal (green/amber on near-black, monospace everything, CRT glow optional)
-
-**Flexible aesthetics (use with caution):**
-- IDE-inspired (borrow a real, named color scheme: Dracula, Nord, Catppuccin Mocha/Latte, Solarized Dark/Light, Gruvbox, One Dark, Rosé Pine) — commit to the actual palette, don't approximate
-- Data-dense (small type, tight spacing, maximum information, muted colors)
-
-**Explicitly forbidden:**
-- Neon dashboard (cyan + magenta + purple on dark) — always produces AI slop
-- Gradient mesh (pink/purple/cyan blobs) — too generic
-- Any combination of Inter font + violet/indigo accents + gradient text
-
-Vary the choice each time. If the last diagram was dark and technical, make the next one light and editorial. The swap test: if you replaced your styling with a generic dark theme and nobody would notice the difference, you haven't designed anything.
-
-### 2. Structure
-
-**Read the reference material** before generating. Don't memorize it — read it each time to absorb the patterns.
-- For text-heavy architecture overviews (card content matters more than topology): read `./templates/architecture.html`
-- For flowcharts, sequence diagrams, ER, state machines, mind maps, class diagrams, C4: read `./templates/mermaid-flowchart.html`
-- For data tables, comparisons, audits, feature matrices: read `./templates/data-table.html`
-- For slide deck presentations (when `--slides` flag is present or `/generate-slides` is invoked): read `./templates/slide-deck.html` and `./references/slide-patterns.md`
-- For prose-heavy publishable pages (READMEs, articles, blog posts, essays): read the "Prose Page Elements" section in `./references/css-patterns.md` and "Typography by Content Voice" in `./references/libraries.md`
-
-**For CSS/layout patterns and SVG connectors**, read `./references/css-patterns.md`.
-
-**For pages with 4+ sections** (reviews, recaps, dashboards), also read `./references/responsive-nav.md` for section navigation with sticky sidebar TOC on desktop and horizontal scrollable bar on mobile.
-
-**Choosing a rendering approach:**
-
-| Content type | Approach | Why |
-|---|---|---|
-| Architecture (text-heavy) | CSS Grid cards + flow arrows | Rich card content (descriptions, code, tool lists) needs CSS control |
-| Architecture (topology-focused) | **Mermaid** | Visible connections between components need automatic edge routing |
-| Flowchart / pipeline | **Mermaid** | Automatic node positioning and edge routing |
-| Sequence diagram | **Mermaid** | Lifelines, messages, and activation boxes need automatic layout |
-| Data flow | **Mermaid** with edge labels | Connections and data descriptions need automatic edge routing |
-| ER / schema diagram | **Mermaid** | Relationship lines between many entities need auto-routing |
-| State machine | **Mermaid** | State transitions with labeled edges need automatic layout |
-| Mind map | **Mermaid** | Hierarchical branching needs automatic positioning |
-| Class diagram | **Mermaid** | Inheritance, composition, aggregation lines with automatic routing |
-| C4 architecture | **Mermaid** | Use `graph TD` + `subgraph` for C4 (not native `C4Context` — it ignores themes) |
-| Data table | HTML `<table>` | Semantic markup, accessibility, copy-paste behavior |
-| Timeline | CSS (central line + cards) | Simple linear layout doesn't need a layout engine |
-| Dashboard | CSS Grid + Chart.js | Card grid with embedded charts |
-
-**Mermaid theming:** Always use `theme: 'base'` with custom `themeVariables` so colors match your page palette. Use `layout: 'elk'` for complex graphs (requires the `@mermaid-js/layout-elk` package — see `./references/libraries.md` for the CDN import). Override Mermaid's SVG classes with CSS for pixel-perfect control. See `./references/libraries.md` for full theming guide.
-
-**Mermaid containers:** Always center Mermaid diagrams with `display: flex; justify-content: center;`. Add zoom controls (+/−/reset/expand) to every `.mermaid-wrap` container. Include the click-to-expand JavaScript so clicking the diagram (or the ⛶ button) opens it full-size in a new tab.
-
-**⚠️ Never use bare `<pre class="mermaid">`.** It renders but has no zoom/pan controls — diagrams become tiny and unusable. Always use the full `diagram-shell` pattern from `templates/mermaid-flowchart.html`: the HTML structure (`.diagram-shell` > `.mermaid-wrap` > `.zoom-controls` + `.mermaid-viewport` > `.mermaid-canvas`), the CSS, and the ~200-line JS module for zoom/pan/fit. Copy it wholesale.
-
-**Mermaid scaling:** Diagrams with 10+ nodes render too small by default. For 10-12 nodes, increase `fontSize` in themeVariables to 18-20px and set `INITIAL_ZOOM` to 1.5-1.6. For 15+ elements, don't try to scale — use the hybrid pattern instead (simple Mermaid overview + CSS Grid cards). See "Architecture / System Diagrams" below.
-
-**Mermaid layout direction:** Prefer `flowchart TD` (top-down) over `flowchart LR` (left-to-right) for complex diagrams. LR spreads horizontally and makes labels unreadable when there are many nodes. Use LR only for simple 3-4 node linear flows. See `./references/libraries.md` "Layout Direction: TD vs LR".
-
-**Mermaid line breaks in flowchart labels:** Use `<br/>` inside quoted labels. Never use escaped newlines like `\n` (Mermaid renders them as literal text in HTML output). Example: `A["Copilot Backend<br/>/api + /api/voicebot"]`.
-
-**Mermaid CSS class collision constraint:** Never define `.node` as a page-level CSS class. Mermaid.js uses `.node` internally on SVG `<g>` elements with `transform: translate(x, y)` for positioning. Page-level `.node` styles (hover transforms, box-shadows) leak into diagrams and break layout. Use the namespaced `.ve-card` class for card components instead. The only safe way to style Mermaid's `.node` is scoped under `.mermaid` (e.g., `.mermaid .node rect`).
-
-**AI-generated illustrations (optional).** If [surf-cli](https://github.com/nicobailon/surf-cli) is available, you can generate images via Gemini and embed them in the page for creative, illustrative, explanatory, educational, or decorative purposes. Check availability with `which surf`. If available:
-
-```bash
-# Generate to a temp file (use --aspect-ratio for control)
-surf gemini "descriptive prompt" --generate-image /tmp/ve-img.png --aspect-ratio 16:9
-
-# Base64 encode for self-containment (macOS)
-IMG=$(base64 -i /tmp/ve-img.png)
-# Linux: IMG=$(base64 -w 0 /tmp/ve-img.png)
-
-# Embed in HTML and clean up
-# <img src="data:image/png;base64,${IMG}" alt="descriptive alt text">
-rm /tmp/ve-img.png
-```
-
-See `./references/css-patterns.md` for image container styles (hero banners, inline illustrations, captions).
-
-**When to use:** Hero banners that establish the page's visual tone. Conceptual illustrations for abstract systems that Mermaid can't express (physical infrastructure, user journeys, mental models). Educational diagrams that benefit from artistic or photorealistic rendering. Decorative accents that reinforce the aesthetic.
-
-**When to skip:** Anything Mermaid or CSS handles well. Generic decoration that doesn't convey meaning. Data-heavy pages where images would distract. Always degrade gracefully — if surf isn't available, skip images without erroring. The page should stand on its own with CSS and typography alone.
-
-**Prompt craft:** Match the image to the page's palette and aesthetic direction. Specify the style (3D render, technical illustration, watercolor, isometric, flat vector, etc.) and mention dominant colors from your CSS variables. Use `--aspect-ratio 16:9` for hero banners, `--aspect-ratio 1:1` for inline illustrations. Keep prompts specific — "isometric illustration of a message queue with cyan nodes on dark navy background" beats "a diagram of a queue."
-
-### 3. Style
-
-Apply these principles to every diagram:
-
-**Typography is the diagram.** Pick a distinctive font pairing from the list in `./references/libraries.md`. Every page should use a different pairing from recent generations.
-
-**Forbidden as `--font-body`:** Inter, Roboto, Arial, Helvetica, system-ui alone. These are AI slop signals.
-
-**Good pairings (use these):**
-- DM Sans + Fira Code (technical, precise)
-- Instrument Serif + JetBrains Mono (editorial, refined)
-- IBM Plex Sans + IBM Plex Mono (reliable, readable)
-- Bricolage Grotesque + Fragment Mono (bold, characterful)
-- Plus Jakarta Sans + Azeret Mono (rounded, approachable)
-
-Load via `<link>` in `<head>`. Include a system font fallback in the `font-family` stack for offline resilience.
-
-**Color tells a story.** Use CSS custom properties for the full palette. Define at minimum: `--bg`, `--surface`, `--border`, `--text`, `--text-dim`, and 3-5 accent colors. Each accent should have a full and a dim variant (for backgrounds). Name variables semantically when possible (`--pipeline-step` not `--blue-3`). Support both themes.
-
-**Forbidden accent colors:** `#8b5cf6` `#7c3aed` `#a78bfa` (indigo/violet), `#d946ef` (fuchsia), the cyan-magenta-pink combination. These are Tailwind defaults that signal zero design intent.
-
-**Good accent palettes (use these):**
-- Terracotta + sage (`#c2410c`, `#65a30d`) — warm, earthy
-- Teal + slate (`#0891b2`, `#0369a1`) — technical, precise
-- Rose + cranberry (`#be123c`, `#881337`) — editorial, refined
-- Amber + emerald (`#d97706`, `#059669`) — data-focused
-- Deep blue + gold (`#1e3a5f`, `#d4a73a`) — premium, sophisticated
-
-Put your primary aesthetic in `:root` and the alternate in the media query:
-
-```css
-/* Light-first (editorial, paper/ink, blueprint): */
-:root { /* light values */ }
-@media (prefers-color-scheme: dark) { :root { /* dark values */ } }
-
-/* Dark-first (neon, IDE-inspired, terminal): */
-:root { /* dark values */ }
-@media (prefers-color-scheme: light) { :root { /* light values */ } }
-```
-
-**Surfaces whisper, they don't shout.** Build depth through subtle lightness shifts (2-4% between levels), not dramatic color changes. Borders should be low-opacity rgba (`rgba(255,255,255,0.08)` in dark mode, `rgba(0,0,0,0.08)` in light) — visible when you look, invisible when you don't.
-
-**Backgrounds create atmosphere.** Don't use flat solid colors for the page background. Subtle gradients, faint grid patterns via CSS, or gentle radial glows behind focal areas. The background should feel like a space, not a void.
-
-**Visual weight signals importance.** Not every section deserves equal visual treatment. Executive summaries and key metrics should dominate the viewport on load (larger type, more padding, subtle accent-tinted background zone). Reference sections (file maps, dependency lists, decision logs) should be compact and stay out of the way. Use `<details>/<summary>` for sections that are useful but not primary — the collapsible pattern is in `./references/css-patterns.md`.
-
-**Surface depth creates hierarchy.** Vary card depth to signal what matters. Hero sections get elevated shadows and accent-tinted backgrounds (`ve-card--hero` pattern). Body content stays flat (default `.ve-card`). Code blocks and secondary content feel recessed (`ve-card--recessed`). See the depth tiers in `./references/css-patterns.md`. Don't make everything elevated — when everything pops, nothing does.
-
-**Animation earns its place.** Staggered fade-ins on page load are almost always worth it — they guide the eye through the diagram's hierarchy. Mix animation types by role: `fadeUp` for cards, `fadeScale` for KPIs and badges, `drawIn` for SVG connectors, `countUp` for hero numbers. Hover transitions on interactive-feeling elements make the diagram feel alive. Always respect `prefers-reduced-motion`. CSS transitions and keyframes handle most cases. For orchestrated multi-element sequences, anime.js via CDN is available (see `./references/libraries.md`).
-
-**Forbidden animations:**
-- Animated glowing box-shadows (`@keyframes glow { box-shadow: 0 0 20px... }`) — this is AI slop
-- Pulsing/breathing effects on static content
-- Continuous animations that run after page load (except for progress indicators)
-
-Keep animations purposeful: entrance reveals, hover feedback, and user-initiated interactions. Nothing should glow or pulse on its own.
-
-### 4. Deliver
-
-**Output location:** Write to `~/.agent/diagrams/`. Use a descriptive filename based on content: `modem-architecture.html`, `pipeline-flow.html`, `schema-overview.html`. The directory persists across sessions.
-
-**Open in browser:**
-- macOS: `open ~/.agent/diagrams/filename.html`
-- Linux: `xdg-open ~/.agent/diagrams/filename.html`
-
-**In Pi package installs, consider offering a visual explanation after generating or reviewing a plan, architecture, diff, or substantial implementation.** Because this can consume many tokens, ask before calling `visual_explainer` with `action: "prepare"` unless the user explicitly requested a diagram, visual review, recap, or visual plan. Use `visual_explainer` with `action: "render"` as the final step: pass a basename-style filename and the complete HTML document; the tool writes under `~/.agent/diagrams/` and opens the page. Otherwise, write the file yourself and open it with `open` or `xdg-open`. Tell the user the file path so they can re-open it.
-
-## Diagram Types
-
-### Architecture / System Diagrams
-Three approaches depending on complexity:
-
-**Simple topology (under 10 elements):** Use Mermaid. A `graph TD` with custom `themeVariables` produces readable diagrams with automatic edge routing.
-
-**Text-heavy overviews (under 15 elements):** CSS Grid with explicit row/column placement. Sections as rounded cards with colored borders and monospace labels. Vertical flow arrows between sections. The reference template at `./templates/architecture.html` demonstrates this pattern. Use when cards need descriptions, code references, tool lists, or other rich content that Mermaid nodes can't hold.
-
-**Complex architectures (15+ elements):** Use the **hybrid pattern** — a simple Mermaid overview (5-8 nodes showing module relationships) followed by detailed CSS Grid cards for each module's internals. This gives you visual topology AND readable details. The overview diagram uses module names with `<small>` tags for key function names. The cards below show full function lists with new/modified badges. Never try to cram 15+ elements into a single Mermaid diagram — it will render unreadably small even with zoom controls.
-
-### Flowcharts / Pipelines
-**Use Mermaid.** Automatic node positioning and edge routing produces proper diagrams with connecting lines, decision diamonds, and parallel branches — dramatically better than CSS flexbox with arrow characters. Prefer `graph TD` (top-down); use `graph LR` only for simple 3-4 node linear flows. Color-code node types with Mermaid's `classDef` or rely on `themeVariables` for automatic styling.
-
-### Sequence Diagrams
-**Use Mermaid.** Lifelines, messages, activation boxes, notes, and loops all need automatic layout. Use Mermaid's `sequenceDiagram` syntax. Style actors and messages via CSS overrides on `.actor`, `.messageText`, `.activation` classes.
-
-### Data Flow Diagrams
-**Use Mermaid.** Data flow diagrams emphasize connections over boxes — exactly what Mermaid excels at. Use `graph TD` (or `graph LR` for simple linear flows) with edge labels for data descriptions. Thicker, colored edges for primary flows. Source/sink nodes styled differently from transform nodes via Mermaid's `classDef`.
-
-### Schema / ER Diagrams
-**Use Mermaid.** Relationship lines between entities need automatic routing. Use Mermaid's `erDiagram` syntax with entity attributes. Style via `themeVariables` and CSS overrides on `.er.entityBox` and `.er.relationshipLine`.
-
-### State Machines / Decision Trees
-**Use Mermaid.** Use `stateDiagram-v2` for states with labeled transitions. Supports nested states, forks, joins, and notes. Decision trees can use `graph TD` with diamond decision nodes.
-
-**`stateDiagram-v2` label caveat:** Transition labels have a strict parser — colons, parentheses, `<br/>`, HTML entities, and most special characters cause silent parse failures ("Syntax error in text"). If your labels need any of these (e.g., `cancel()`, `curate: true`, multi-line labels), use `flowchart TD` instead with rounded nodes and quoted edge labels (`|"label text"|`). Flowcharts handle all special characters and support `<br/>` for line breaks. Reserve `stateDiagram-v2` for simple single-word or plain-text labels.
-
-### Mind Maps / Hierarchical Breakdowns
-**Use Mermaid.** Use `mindmap` syntax for hierarchical branching from a root node. Mermaid handles the radial layout automatically. Style with `themeVariables` to control node colors at each depth level.
-
-### Class Diagrams
-**Use Mermaid.** Use `classDiagram` syntax for domain modeling, OOP design, and entity relationships with typed properties and methods. Supports relationships: association (`-->`), composition (`*--`), aggregation (`o--`), and inheritance (`<|--`). Add multiplicity labels (e.g., `"1" --> "*"`) and abstract/interface markers (`<<interface>>`, `<<abstract>>`). For simple entity boxes without OOP semantics (no methods, no inheritance), prefer `erDiagram` instead — it produces cleaner output for pure data modeling.
-
-### C4 Architecture Diagrams
-**Use Mermaid flowchart syntax — NOT native C4.** Use `graph TD` with `subgraph` blocks for C4 boundaries. Native `C4Context` hardcodes sharp corners, its own font, blue icons, and inline SVG colors that ignore `themeVariables` — it always clashes with custom palettes.
-
-**Flowchart-as-C4 pattern:** Persons → rounded nodes `(("Name"))`, systems → rectangles `["Name"]`, databases → cylinders `[("Name")]`, boundaries → `subgraph` blocks, relationships → labeled arrows `-->|"protocol"|`. Use `classDef` + `:::className` to visually differentiate external systems (e.g., dashed borders). This inherits `themeVariables`, `fontFamily`, and CSS overrides like every other Mermaid diagram.
-
-### Data Tables / Comparisons / Audits
-Use a real `<table>` element — not CSS Grid pretending to be a table. Tables get accessibility, copy-paste behavior, and column alignment for free. The reference template at `./templates/data-table.html` demonstrates all patterns below.
-
-**Use proactively.** Any time you'd render an ASCII box-drawing table in the terminal, generate an HTML table instead. This includes: requirement audits (request vs plan), feature comparisons, status reports, configuration matrices, test result summaries, dependency lists, permission tables, API endpoint inventories — any structured rows and columns.
-
-Layout patterns:
-- Sticky `<thead>` so headers stay visible when scrolling long tables
-- Alternating row backgrounds via `tr:nth-child(even)` (subtle, 2-3% lightness shift)
-- First column optionally sticky for wide tables with horizontal scroll
-- Responsive wrapper with `overflow-x: auto` for tables wider than the viewport
-- Column width hints via `<colgroup>` or `th` widths — let text-heavy columns breathe
-- Row hover highlight for scanability
-
-Status indicators (use styled `<span>` elements, never emoji):
-- Match/pass/yes: colored dot or checkmark with green background
-- Gap/fail/no: colored dot or cross with red background
-- Partial/warning: amber indicator
-- Neutral/info: dim text or muted badge
-
-Cell content:
-- Wrap long text naturally — don't truncate or force single-line
-- Use `<code>` for technical references within cells
-- Secondary detail text in `<small>` with dimmed color
-- Keep numeric columns right-aligned with `tabular-nums`
-
-### Timeline / Roadmap Views
-Vertical or horizontal timeline with a central line (CSS pseudo-element). Phase markers as circles on the line. Content cards branching left/right (alternating) or all to one side. Date labels on the line. Color progression from past (muted) to future (vivid).
-
-### Dashboard / Metrics Overview
-Card grid layout. Hero numbers large and prominent. Sparklines via inline SVG `<polyline>`. Progress bars via CSS `linear-gradient` on a div. For real charts (bar, line, pie), use **Chart.js via CDN** (see `./references/libraries.md`). KPI cards with trend indicators (up/down arrows, percentage deltas).
-
-### Implementation Plans
-
-For visualizing implementation plans, extension designs, or feature specifications. The goal is **understanding the approach**, not reading the full source code.
-
-**Don't dump full files.** Displaying entire source files inline overwhelms the page and defeats the purpose of a visual explanation. Instead:
-- Show **file structure with descriptions** — list functions/exports with one-line explanations
-- Show **key snippets only** — the 5-10 lines that illustrate the core logic
-- Use **collapsible sections** for full code if truly needed
-
-**Code blocks require explicit formatting.** Without `white-space: pre-wrap`, code runs together into an unreadable wall. See the "Code Blocks" section in `./references/css-patterns.md` for the correct pattern.
-
-**Structure for implementation plans:**
-1. Overview/purpose (what problem does this solve?)
-2. Flow diagram (Mermaid or CSS cards)
-3. File structure with descriptions (not full code)
-4. Key implementation details (snippets)
-5. API/interface summary
-6. Usage examples
-
-### Documentation (READMEs, Library Docs, API References)
-
-When visualizing documentation, extract structure into visual elements:
-
-| Content | Visual Treatment |
-|---------|------------------|
-| Features | Card grid (2-3 columns) |
-| Install/setup steps | Numbered cards or vertical flow |
-| API endpoints/commands | Table with sticky header |
-| Config options | Table |
-| Architecture | Mermaid diagram or CSS card layout |
-| Comparisons | Side-by-side panels or table |
-| Warnings/notes | Callout boxes |
-
-Don't just format the prose — transform it. A feature list becomes a card grid. Install steps become a numbered flow. An API reference becomes a table.
-
-### Prose Accent Elements
-
-Use these sparingly within visual pages to highlight key points or provide breathing room. See "Prose Page Elements" in `./references/css-patterns.md` for CSS patterns.
-
-- **Lead paragraph** — larger intro text to set context before diving into cards/grids
-- **Pull quote** — highlight a key insight; one per page maximum
-- **Callout box** — warnings, tips, important notes
-- **Section divider** — visual break between major sections
-
-**When to use:** A visual page explaining an essay might use a lead paragraph for the thesis, then cards for key arguments. A README visualization might use callout boxes for warnings but otherwise stay card/table-focused.
-
-## Slide Deck Mode
-
-An alternative output format for presenting content as a magazine-quality slide presentation instead of a scrollable page. **Opt-in only** — the agent generates slides when the user invokes `/generate-slides`, passes `--slides` to an existing prompt (e.g., `/diff-review --slides`), or explicitly asks for a slide deck. Never auto-select slide format.
-
-**Before generating slides**, read `./references/slide-patterns.md` (engine CSS, slide types, transitions, nav chrome, presets) and `./templates/slide-deck.html` (reference template showing all 10 types). Also read `./references/css-patterns.md` for shared patterns and `./references/libraries.md` for Mermaid/Chart.js theming.
-
-**Slides are not pages reformatted.** They're a different medium. Each slide is exactly one viewport tall (100dvh) with no scrolling. Typography is 2–3× larger. Compositions are bolder. The agent composes a narrative arc (impact → context → deep dive → resolution) rather than mechanically paginating the source.
-
-**Content completeness.** Changing the medium does not mean dropping content. Follow the "Planning a Deck from a Source Document" process in `slide-patterns.md` before writing any HTML: inventory the source, map every item to slides, verify coverage. Every section, decision, data point, specification, and collapsible detail from the source must appear in the deck. If a plan has 7 sections, the deck covers all 7. If there are 6 decisions, present all 6 — not the 2 that fit on one slide. Collapsible details in the source become their own slides. Add more slides rather than cutting content. A 22-slide deck that covers everything beats a 13-slide deck that looks polished but is missing 40% of the source.
-
-**Slide types (10):** Title, Section Divider, Content, Split, Diagram, Dashboard, Table, Code, Quote, Full-Bleed. Each has a defined layout in `slide-patterns.md`. Content that exceeds a slide's density limit splits across multiple slides — never scrolls within a slide.
-
-**Visual richness:** Check `which surf` at the start. If surf-cli is available, generate 2–4 images (title slide background, full-bleed background, optional content illustrations) before writing HTML — see the Proactive Imagery section in `slide-patterns.md` for the workflow. Also use SVG decorative accents, per-slide background gradients, inline sparklines, and small Mermaid diagrams. Visual-first, text-second.
-
-**Compositional variety:** Consecutive slides must vary spatial approach — centered, left-heavy, right-heavy, split, edge-aligned, full-bleed. Three centered slides in a row means push one off-axis.
-
-**Curated presets:** Four slide-specific presets as starting points (Midnight Editorial, Warm Signal, Terminal Mono, Swiss Clean) plus the existing 8 aesthetic directions adapted for slides. Pick one and commit. See `slide-patterns.md` for preset CSS values.
-
-**`--slides` flag on existing prompts:** When a user passes `--slides` to `/diff-review`, `/plan-review`, `/project-recap`, or other prompts, the agent gathers data using the prompt's normal data-gathering instructions, then presents the content as a slide deck instead of a scrollable page. The slide version tells the same story with different structure and pacing — but the same breadth of coverage. Don't use the slide format as an excuse to summarize or skip sections that the scrollable version would have included.
-
-## File Structure
-
-Every diagram is a single self-contained `.html` file. No external assets except CDN links (fonts, optional libraries). Structure:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Descriptive Title</title>
-  <link href="https://fonts.googleapis.com/css2?family=...&display=swap" rel="stylesheet">
-  <style>
-    /* CSS custom properties, theme, layout, components — all inline */
-  </style>
-</head>
-<body>
-  <!-- Semantic HTML: sections, headings, lists, tables, inline SVG -->
-  <!-- No script needed for static CSS-only diagrams -->
-  <!-- Optional: <script> for Mermaid, Chart.js, or anime.js when used -->
-</body>
-</html>
-```
-
-## Quality Checks
-
-Before delivering, verify:
-- **The squint test**: Blur your eyes. Can you still perceive hierarchy? Are sections visually distinct?
-- **The swap test**: Would replacing your fonts and colors with a generic dark theme make this indistinguishable from a template? If yes, push the aesthetic further.
-- **Both themes**: Toggle your OS between light and dark mode. Both should look intentional, not broken.
-- **Information completeness**: Does the diagram actually convey what the user asked for? Pretty but incomplete is a failure.
-- **No overflow**: Resize the browser to different widths. No content should clip or escape its container. Every grid and flex child needs `min-width: 0`. Side-by-side panels need `overflow-wrap: break-word`. Never use `display: flex` on `<li>` for marker characters — it creates anonymous flex items that can't shrink, causing lines with many inline `<code>` badges to overflow. Use absolute positioning for markers instead. See the Overflow Protection section in `./references/css-patterns.md`.
-- **Mermaid zoom controls**: Every `.mermaid-wrap` container must have zoom controls (+/−/reset/expand buttons), Ctrl/Cmd+scroll zoom, click-and-drag panning, and click-to-expand (clicking without dragging opens the diagram full-size in a new tab). The expand button (⛶) provides the same functionality. See `./references/css-patterns.md` for the full pattern including the `openMermaidInNewTab()` function.
-- **File opens cleanly**: No console errors, no broken font loads, no layout shifts.
-
-## Anti-Patterns (AI Slop)
-
-These patterns are explicitly forbidden. They signal "AI-generated template" and undermine the skill's purpose of producing distinctive, high-quality diagrams. Review every generated page against this list.
-
-### Typography
-
-**Forbidden fonts as primary `--font-body`:**
-- Inter — the single most overused AI default
-- Roboto, Arial, Helvetica — generic system fallbacks promoted to primary
-- system-ui, sans-serif alone — no character, no intent
-
-**Required:** Pick from the font pairings in `./references/libraries.md`. Every generation should use a different pairing from the last.
-
-### Color Palette
-
-**Forbidden accent colors:**
-- Indigo-500/violet-500 (`#8b5cf6`, `#7c3aed`, `#a78bfa`) — Tailwind's default purple range
-- The cyan + magenta + pink neon gradient combination (`#06b6d4` → `#d946ef` → `#f472b6`)
-- Any palette that could be described as "Tailwind defaults with purple/pink/cyan accents"
-
-**Forbidden color effects:**
-- Gradient text on headings (`background: linear-gradient(...); background-clip: text;`) — this screams AI-generated
-- Animated glowing box-shadows on cards (`box-shadow: 0 0 20px var(--glow); animation: glow 2s...`)
-- Multiple overlapping radial glows in accent colors creating a "neon haze"
-
-**Required:** Build palettes from the reference templates (terracotta/sage, teal/cyan, rose/cranberry, slate/blue) or derive from real IDE themes (Dracula, Nord, Solarized, Gruvbox, Catppuccin). Accents should feel intentional, not default.
-
-### Section Headers
-
-**Forbidden:**
-- Emoji icons in section headers (🏗️, ⚙️, 📁, 💻, 📅, 🔗, ⚡, 🔧, 📦, 🚀, etc.)
-- Section headers that all use the same icon-in-rounded-box pattern
-
-**Required:** Use styled monospace labels with colored dot indicators (see `.section-label` in templates), numbered badges (`section__num` pattern), or asymmetric section dividers. If an icon is genuinely needed, use an inline SVG that matches the palette — not emoji.
-
-### Layout & Hierarchy
-
-**Forbidden:**
-- Perfectly centered everything with uniform padding
-- All cards styled identically with the same border-radius, shadow, and spacing
-- Every section getting equal visual treatment — no hero/primary vs. secondary distinction
-- Symmetric layouts where left and right halves mirror each other
-
-**Required:** Vary visual weight. Hero sections should dominate (larger type, more padding, accent-tinted background). Reference sections should feel compact. Use the depth tiers (hero → elevated → default → recessed). Asymmetric layouts create interest.
-
-### Template Patterns
-
-**Forbidden:**
-- Three-dot window chrome (red/yellow/green dots) on code blocks — this is a cliché
-- KPI cards where every metric has identical gradient text treatment
-- "Neon Dashboard" as an aesthetic choice — it always produces generic results
-- Gradient meshes with pink/purple/cyan blobs in the background
-
-**Required:** Code blocks use a simple header with filename or language label. KPI cards vary by importance — hero numbers for the primary metric, subdued treatment for supporting metrics. Pick aesthetics with natural constraints: Blueprint (must feel technical/precise), Editorial (must have generous whitespace and serif typography), Paper/ink (must feel warm and informal).
-
-### The Slop Test
-
-Before delivering, apply this test: **Would a developer looking at this page immediately think "AI generated this"?** The telltale signs:
-
-1. Inter or Roboto font with purple/violet gradient accents
-2. Every heading has `background-clip: text` gradient
-3. Emoji icons leading every section
-4. Glowing cards with animated shadows
-5. Cyan-magenta-pink color scheme on dark background
-6. Perfectly uniform card grid with no visual hierarchy
-7. Three-dot code block chrome
-
-If two or more of these are present, the page is slop. Regenerate with a different aesthetic direction — Editorial, Blueprint, Paper/ink, or a specific IDE theme. These constrained aesthetics are harder to mess up because they have specific visual requirements that prevent defaulting to generic patterns.
+Generate self-contained HTML pages that explain systems, code changes, plans, data, and technical concepts visually. Use this skill for diagram requests, architecture overviews, diff/plan reviews, project recaps, comparison tables, slide decks, and any visual explanation.
+
+## Trigger and delivery rules
+
+- Prefer an HTML page over terminal ASCII when the output is inherently visual.
+- If a table would have 4+ rows or 3+ columns, render it as HTML and give only a short chat summary.
+- Write files to `~/.agent/diagrams/` or the explicit eval output path. Use descriptive filenames.
+- Open generated pages in the browser when running normally. In Pi package installs, use `visual_explainer` with `prepare` for planning/context and `render` only after the complete HTML document exists.
+- The final page must be a complete self-contained HTML document, including embedded CSS and any needed JS.
+
+## Reference routing
+
+Read only the references needed for the current output:
+
+| Need | Read |
+|---|---|
+| Text-heavy architecture/cards | `./templates/architecture.html` |
+| Mermaid flowcharts, sequence, ER, state, class, C4, data flow | `./templates/mermaid-flowchart.html`, Mermaid sections in `./references/libraries.md` |
+| Data tables, comparisons, audits | `./templates/data-table.html` |
+| Slide decks | `./templates/slide-deck.html`, `./references/slide-patterns.md` |
+| CSS layout, overflow, depth, collapsibles, SVG connectors, generated images | `./references/css-patterns.md` |
+| Pages with 4+ major sections | `./references/responsive-nav.md` |
+| Prose-heavy pages | “Prose Page Elements” in `css-patterns.md`, typography sections in `libraries.md` |
+
+## Choose the representation
+
+| Content | Default representation |
+|---|---|
+| Flowchart, pipeline, state machine, decision tree | Mermaid |
+| Sequence, ER/schema, class, C4, topology-focused architecture | Mermaid |
+| Text-heavy architecture, module internals, implementation plans | CSS grid cards, optionally with a Mermaid overview |
+| 15+ element architecture | Hybrid: small Mermaid overview + CSS detail cards |
+| Comparison/audit/status matrix | Semantic HTML `<table>` |
+| Timeline/roadmap | CSS timeline |
+| Dashboard/metrics | CSS grid + charts/KPIs |
+| Slide deck | `100dvh` slides using slide template patterns |
+
+## Mermaid invariants
+
+- Use `theme: 'base'` with custom `themeVariables` matching the page palette.
+- For complex diagrams use ELK layout when available.
+- Never use bare `<pre class="mermaid">`.
+- Use the canonical `diagram-shell` pattern from `templates/mermaid-flowchart.html`: `.diagram-shell` > `.mermaid-wrap` > `.zoom-controls` + `.mermaid-viewport` > `.mermaid-canvas`.
+- Every Mermaid diagram needs zoom in/out/reset/expand controls, Ctrl/Cmd+scroll zoom, drag panning, and click-to-expand.
+- Prefer `flowchart TD` for complex diagrams. Use `LR` only for simple 3–4 node linear flows.
+- Use `<br/>` in quoted flowchart labels. Do not use escaped `\n` labels.
+- Never define page-level `.node`; Mermaid uses it internally. Use namespaced page classes such as `.ve-card`.
+- For 15+ elements, do not cram everything into one Mermaid diagram. Use the hybrid overview + cards pattern.
+
+## Layout and style invariants
+
+- Use semantic HTML where it helps accessibility and copy/paste: `<table>`, headings, lists, `<details>`, captions.
+- Use CSS custom properties for palette: `--bg`, `--surface`, `--border`, `--text`, `--text-dim`, and 3–5 accents.
+- Pick a clear aesthetic direction before writing: blueprint, editorial, paper/ink, terminal, IDE-inspired, or data-dense.
+- Avoid generic defaults: no body font that is only Inter, Roboto, Arial, Helvetica, or system-ui; no violet/fuchsia Tailwind-default accents as the main palette (`#8b5cf6`, `#7c3aed`, `#a78bfa`, `#d946ef`); no cyan+magenta+purple neon dashboard; no gradient-mesh blobs.
+- Good font pair families: DM Sans + Fira Code; Instrument Serif + JetBrains Mono; IBM Plex Sans + IBM Plex Mono; Bricolage Grotesque + Fragment Mono; Plus Jakarta Sans + Azeret Mono.
+- Good accent directions: terracotta+sage, teal+slate, rose+cranberry, amber+emerald, deep blue+gold.
+- Prevent overflow: `min-width: 0` on grid/flex children, `overflow-wrap: break-word` for long text, and scroll containers for wide tables/code.
+- Do not set `display: flex` directly on `<li>` when list markers matter.
+- Use depth sparingly: hero/elevated only for primary sections; flat/recessed for reference material.
+- Use entrance/hover animation only when it clarifies hierarchy. Respect `prefers-reduced-motion`. Do not use continuous glow, pulse, or breathing effects on static content.
+
+## Slide deck mode
+
+Use slides only when explicitly requested or when a command asks for slides. Slides are a different medium, not a paginated article:
+
+- Each slide is one viewport (`100dvh`) with no page-level scrolling.
+- Use larger type, fewer objects per slide, varied compositions, and visible navigation.
+- Include slide nav chrome from `slide-deck.html`: prev/next controls, slide count, keyboard navigation, and carousel dots/indicators.
+- Before writing HTML, inventory the source and map every source item to slides.
+- Do not drop content to fit a fixed slide count. Add slides instead.
+- Use the 10 slide types from `slide-patterns.md`: Title, Section Divider, Content, Split, Diagram, Dashboard, Table, Code, Quote, Full-Bleed.
+
+## Optional generated images
+
+If `surf` is available, generated images may be embedded as base64 for hero banners, conceptual illustrations, or educational visuals. Skip images for data-heavy, structural, or Mermaid/CSS-suitable content. Pages must stand on CSS, typography, and diagrams without images.
+
+## Final checklist
+
+Before delivery, verify:
+
+- complete HTML document;
+- output written to the requested path;
+- no console errors when opened;
+- no horizontal overflow at normal desktop width;
+- fonts load with fallbacks;
+- tables preserve rows/columns and wrap long text;
+- Mermaid diagrams use `diagram-shell` with zoom/pan/expand;
+- slides fit one viewport, include carousel dots, and preserve source coverage;
+- visual hierarchy makes the main idea obvious in the first viewport;
+- styling would still be recognizable if compared against a generic dark/violet template.

--- a/plugins/visual-explainer/commands/diff-review.md
+++ b/plugins/visual-explainer/commands/diff-review.md
@@ -1,68 +1,38 @@
 ---
-description: Generate a visual HTML diff review — before/after architecture comparison with code review analysis
+description: Generate a visual diff review for code changes
 ---
-Load the visual-explainer skill, then generate a comprehensive visual diff review as a self-contained HTML page.
 
-Follow the visual-explainer skill workflow. Read the reference template, CSS patterns, and mermaid theming references before generating. Use a GitHub-diff-inspired aesthetic with red/green before/after panels, but vary fonts and palette from previous diagrams.
+Load the visual-explainer skill and generate a self-contained HTML diff review.
 
-**Scope detection** — determine what to diff based on `$1`:
-- Branch name (e.g. `main`, `develop`): working tree vs that branch
-- Commit hash: that specific commit's diff (`git show <hash>`)
-- `HEAD`: uncommitted changes only (`git diff` and `git diff --staged`)
-- PR number (e.g. `#42`): `gh pr diff 42`
-- Range (e.g. `abc123..def456`): diff between two commits
-- No argument: default to `main`
+## Scope detection
 
-**Data gathering phase** — run these first to understand the full scope:
-- `git diff --stat <ref>` for file-level overview
-- `git diff --name-status <ref> --` for new/modified/deleted files (separate src from tests)
-- Line counts: compare key files between `<ref>` and working tree (`git show <ref>:file | wc -l` vs `wc -l`)
-- New public API surface: grep added lines for exported symbols, public functions, classes, interfaces (adapt the pattern to the project's language — `export`/`function`/`class`/`interface` for TS/JS, `def`/`class` for Python, `func`/`type` for Go, etc.)
-- Feature inventory: grep for new actions, keybindings, config fields, event types on both sides
-- Read all changed files in full — include surrounding code paths needed to validate behavior
-- Check whether `CHANGELOG.md` has an entry for these changes
-- Check whether `README.md` or `docs/*.md` need updates given any new or changed features
-- Reconstruct decision rationale: if this work was done in the current session, mine the conversation for approaches discussed, alternatives rejected, and trade-offs made. Check for progress docs (`~/.agent/memory/{project}/progress.md`, `~/.pi/agent/memory/{project}/progress.md`) or plan files that may contain reasoning. For committed changes, read commit messages and PR descriptions.
+Interpret `$@` as a branch, commit, range, PR, or `HEAD`. If no argument is given, compare the working tree against `main`/`master`.
 
-**Verification checkpoint** — before generating HTML, produce a structured fact sheet of every claim you will present in the review:
-- Every quantitative figure: line counts, file counts, function counts, test counts
-- Every function, type, and module name you will reference
-- Every behavior description: what code does, what changed, before vs. after
-- For each, cite the source: the git command output that produced it, or the file:line where you read it
-Verify each claim against the code. If something cannot be verified, mark it as uncertain rather than stating it as fact. This fact sheet is your source of truth during HTML generation — do not deviate from it.
+## Data gathering before HTML
 
-**Diagram structure** — the page should include:
-1. **Executive summary** — not just a dry before/after. Lead with the *intuition*: why do these changes exist? What problem were they solving, what was the core insight? Then the factual scope (X files, Y lines, Z new modules). Aim for "aha moment" clarity — a reader who only sees this section should understand the essence of the change. *Visual treatment: this is the visual anchor — use hero depth (larger type 20-24px, subtle accent-tinted background, more padding than other sections).*
-2. **KPI dashboard** — lines added/removed, files changed, new modules, test counts. Include a **housekeeping** indicator: whether CHANGELOG.md was updated (green/red badge) and whether docs need changes (green/yellow/red).
-3. **Module architecture** — how the file structure changed, with a Mermaid dependency graph of the current state. Wrap in `.mermaid-wrap` with zoom controls (+/−/reset/expand buttons), Ctrl/Cmd+scroll zoom, click-and-drag panning, and click-to-expand (opens diagram full-size in new tab). See css-patterns.md "Mermaid Zoom Controls" for the full pattern including the `openMermaidInNewTab()` function.
-4. **Major feature comparisons** — side-by-side before/after panels for each significant area of change (UI, data flow, API surface, config, etc.). Overflow prevention: apply `min-width: 0` on all grid/flex children and `overflow-wrap: break-word` on panels. Never use `display: flex` on `<li>` for marker characters — use absolute positioning instead (see css-patterns.md Overflow Protection).
-5. **Flow diagrams** — Mermaid flowchart, sequence, or state diagrams for any new lifecycle/pipeline/interaction patterns. Same zoom controls and click-to-expand as section 3.
-6. **File map** — full tree with color-coded new/modified/deleted indicators. *Visual treatment: compact — consider `<details>` collapsed by default for pages with many sections.*
-7. **Test coverage** — before/after test file counts and what's covered
-8. **Code review** — structured Good/Bad/Ugly analysis of the changes:
-   - **Good**: Solid choices, improvements, clean patterns worth calling out
-   - **Bad**: Concrete issues — bugs, regressions, missing error handling, logic errors
-   - **Ugly**: Subtle problems — tech debt introduced, maintainability concerns, things that work now but will bite later
-   - **Questions**: Anything unclear or that needs the author's clarification
-   - Use styled cards with green/red/amber/blue left-border accents matching the diff color language. Each item should reference specific files and line ranges. If nothing to flag in a category, say "None found" rather than omitting the section.
-9. **Decision log** — for each significant design choice in the diff, a styled card with:
-   - **Decision**: one-line summary of what was decided (e.g., "Promise-based deferred resolution instead of event emitters for cleanup signaling")
-   - **Rationale**: why this approach — constraints, trade-offs, what it enables. Pull from conversation context if available, infer from code structure if not.
-   - **Alternatives considered**: what was rejected and why, if recoverable
-   - **Confidence**: whether this rationale was explicitly discussed (high — sourced from conversation/docs) or inferred from the code (medium — flagged as inference). Low confidence means the rationale couldn't be recovered at all.
-   - Visual treatment by confidence level — use left-border accent colors consistent with the diff color language: **High** (sourced from conversation/docs): green left border. **Medium** (inferred from code): blue left border, labeled "inferred." **Low** (not recoverable): amber left border, "rationale not recoverable — document before committing" warning. Low-confidence cards are cognitive debt hotspots — tell the user to document the reasoning before committing.
-10. **Re-entry context** — a concise "note from present-you to future-you" covering the following. *Visual treatment: compact — consider `<details>` collapsed by default for pages with many sections.*
-   - **Key invariants**: assumptions the changed code relies on that aren't enforced by types or tests (e.g., "cleanup must be called before session switch or artifacts leak")
-   - **Non-obvious coupling**: files or behaviors that are connected in ways that aren't visible from imports alone (e.g., "the feed renderer reads events written by the overlay — changing the event schema requires updating both")
-   - **Gotchas**: things that would surprise someone modifying this code in two weeks. Edge cases, ordering dependencies, implicit contracts.
-   - **Don't forget**: if the changes require follow-up work (migration, config update, docs), list it here.
+Run the relevant git commands for: diff stats, name-status, changed files, line counts, public API/type/function changes, added/removed files, docs/changelog changes, tests touched, dependencies/config changes. Read changed files in full plus surrounding code paths needed to validate behavior. If reviewing committed work, read commit messages. If this session created the work, use available progress/plan notes for rationale.
 
-**Visual hierarchy**: Sections 1-3 should dominate the viewport on load (hero depth, larger type, more padding). Sections 6+ are reference material and should feel lighter (flat or recessed depth, compact layout, collapsible where appropriate).
+## Source verification
 
-**Optional illustrations** — if `surf` CLI is available (`which surf`), consider generating a hero banner or conceptual illustration via `surf gemini --generate-image` when it would enhance the page. Embed as base64 data URI. See css-patterns.md "Generated Images" for container styles. Skip if surf isn't available or the diff is purely structural.
+Before generating, know and cite:
 
-Include responsive section navigation. Use diff-style visual language throughout: red for removed/before, green for added/after, yellow for modified, blue for neutral context. Write to `~/.agent/diagrams/` and open in browser.
+- exact changed files and line-count scope;
+- each function/type/module name referenced;
+- before/after behavior for important changes;
+- likely coupling and test impact.
 
-Ultrathink.
+Use file paths, command outputs, or file:line evidence. Do not invent rationale or code paths.
 
-$@
+## Required page sections
+
+1. Executive summary: intuition, problem solved, factual scope.
+2. File map: full tree, color-coded new/modified/deleted; compact, `<details>` if long.
+3. Architecture impact: Mermaid or hybrid diagram when relationships matter.
+4. Before/after behavior: side-by-side visual comparison.
+5. Risk review: correctness, tests, API compatibility, security/privacy, performance, maintainability.
+6. Coupling map: dependencies, hidden coupling, migration/release concerns.
+7. Review recommendation: merge/readiness, blockers, follow-ups.
+
+Use diff color language consistently: red removed/before, green added/after, amber modified/risk, blue neutral context. Use responsive section navigation for 4+ sections. Follow the skill’s Mermaid and overflow rules.
+
+Write to `~/.agent/diagrams/` and open in browser.

--- a/plugins/visual-explainer/commands/fact-check.md
+++ b/plugins/visual-explainer/commands/fact-check.md
@@ -1,63 +1,15 @@
 ---
-description: Verify the factual accuracy of a document against the actual codebase, correct inaccuracies in place
+description: Verify a generated document against actual code and git history
 ---
-Load the visual-explainer skill, then verify the factual accuracy of a document that makes claims about a codebase. Read the file, extract every verifiable claim, check each against the actual code and git history, correct inaccuracies in place, and add a verification summary.
 
-For HTML files: read `./references/css-patterns.md` to match the existing page's styling when inserting the verification summary.
+Load the visual-explainer skill and fact-check the document named by `$@`. If no argument is given, use the most recently modified HTML file in `~/.agent/diagrams/`.
 
-**Target file** — determine what to verify from `$1`:
-- Explicit path: verify that specific file (`.html`, `.md`, or any text document)
-- No argument: verify the most recently modified `.html` file in `~/.agent/diagrams/` (`ls -t ~/.agent/diagrams/*.html | head -1`)
+## Claim extraction
 
-Auto-detect the document type and adjust the verification strategy:
-- **HTML review pages** (diff-review, plan-review, project-recap): detect from page content, verify against the git ref or plan file the review was based on
-- **Plan/spec documents** (markdown): verify file references, function/type names, behavior descriptions, and architecture claims against the current codebase
-- **Any other document**: extract and verify whatever factual claims about code it contains
+Read the target document. Extract verifiable claims about file paths, function/type/module names, behavior, architecture, data flow, APIs, commands, dependencies, tests, performance/security assertions, and git history. Skip subjective design opinions.
 
-**Phase 1: Extract claims.** Read the file. Extract every verifiable factual claim:
-- **Quantitative**: line counts, file counts, function counts, module counts, test counts, any numeric metrics
-- **Naming**: function names, type names, module names, file paths referenced in the document
-- **Behavioral**: descriptions of what code does, how things work, before/after comparisons
-- **Structural**: architecture claims, dependency relationships, import chains, module boundaries
-- **Temporal**: git history claims, commit attributions, timeline entries
+## Verification
 
-Skip subjective analysis (opinions, design judgments, readability assessments) — these aren't verifiable facts.
+For each claim, inspect the actual source or git history. Re-read referenced files. For diff reviews, compare before/after with `git show` or the relevant range. For plan docs, verify referenced files/functions/types exist and behave as described.
 
-**Phase 2: Verify against source.** For each extracted claim, go to the source:
-- Re-read every file referenced in the document — check function signatures, type definitions, behavior descriptions against the actual code
-- For claims about git history: re-run git commands (`git diff --stat`, `git log`, `git diff --name-status`, etc.) and compare output against the document's numbers
-- For diff-reviews: read both the ref version (`git show <ref>:file`) and working tree version to verify before/after claims aren't swapped or fabricated
-- For plan docs: verify that files, functions, and types the plan references actually exist and behave as described
-- For project-recaps: re-run `git log` commands to verify activity narrative and timeline
-
-Classify each claim:
-- **Confirmed**: claim matches the code/output exactly
-- **Corrected**: claim was inaccurate — note what was wrong and what the correct value is
-- **Unverifiable**: claim can't be checked (e.g., references a file that doesn't exist, or a behavior that requires runtime testing)
-
-**Phase 3: Correct in place.** Edit the file directly using surgical text replacements:
-- Fix incorrect numbers, function names, file paths, behavior descriptions
-- Fix before/after swaps (a common error class in review pages)
-- If a section is fundamentally wrong (not just a detail error), rewrite that section's content while preserving the surrounding structure
-- For HTML: preserve layout, CSS, animations, Mermaid diagrams (unless they contain factual errors in node labels or edge descriptions)
-- For markdown: preserve heading structure, formatting, and document organization
-
-**Phase 4: Add verification summary.**
-- **HTML files**: insert a verification section as a banner at the top or final section, matching the page's existing styling. Use a subtle card with muted colors.
-- **Markdown files**: append a `## Verification Summary` section at the end of the document.
-
-Include in the summary:
-- Total claims checked
-- Claims confirmed (with count)
-- Corrections made (with brief list of what was fixed: "Changed `processCleanup` to `runCleanup` to match actual function name in `worker.ts:45`")
-- Unverifiable claims flagged (if any)
-
-**Phase 5: Report.** Tell the user what was checked, what was corrected, and open the file (HTML in browser, markdown path in chat). If nothing needed correction, say so — the verification still has value as confirmation.
-
-This is not a re-review. It does not second-guess analysis, opinions, or design judgments. It does not change the document's structure or organization. It is a fact-checker — it verifies that the data presented matches reality, corrects what doesn't, and leaves everything else alone.
-
-Write corrections to the original file.
-
-Ultrathink.
-
-$@
+Classify claims as verified, corrected, unsupported, or unverifiable. Preserve the document’s structure. Correct factual errors in place and add a verification summary that lists what was checked and changed. For HTML, match the existing page style and open it in the browser. For markdown, report the path in chat.

--- a/plugins/visual-explainer/commands/generate-slides.md
+++ b/plugins/visual-explainer/commands/generate-slides.md
@@ -1,18 +1,13 @@
 ---
-description: Generate a stunning magazine-quality slide deck as a self-contained HTML page
+description: Generate a slide deck as a self-contained HTML page
 ---
-Load the visual-explainer skill, then generate a slide deck for: $@
 
-Follow the visual-explainer skill workflow. Read the reference template at `./templates/slide-deck.html` and slide patterns at `./references/slide-patterns.md` before generating. Also read `./references/css-patterns.md` for shared patterns (Mermaid zoom controls, depth tiers, overflow protection) and `./references/libraries.md` for Mermaid theming, Chart.js, and font pairings.
+Load the visual-explainer skill and generate a slide deck for: $@
 
-**Slide output is always opt-in.** Only generate slides when this command is invoked or the user explicitly asks for a slide deck.
+Before writing HTML, read `./templates/slide-deck.html`, `./references/slide-patterns.md`, and only the shared CSS/library sections needed for the source.
 
-**Aesthetic:** Pick a distinctive direction from the 4 slide presets in slide-patterns.md (Midnight Editorial, Warm Signal, Terminal Mono, Swiss Clean) or riff on the existing 8 aesthetic directions adapted for slides. Vary from previous decks. Commit to one direction and carry it through every slide.
+Plan the deck first: inventory the source, map every item to slides, choose a narrative arc, and assign a composition to each slide. Use the 10 slide types and nav chrome from `slide-patterns.md`/`slide-deck.html`, including carousel dots, prev/next, slide count, and keyboard controls. Keep each slide to `100dvh`; split dense content across slides rather than scrolling or dropping content.
 
-**Narrative structure:** Slides have a temporal dimension — compose a story arc, not a list of sections. Start with impact (title), build context (overview), deep dive (content, diagrams, data), resolve (summary/next steps). Plan the slide sequence and assign a composition (centered, left-heavy, split, full-bleed) to each slide before writing HTML.
+Use visual-first slides: diagrams, charts, tables, SVG accents, and images from `surf` only when they clarify the story. Vary compositions; three centered slides in a row is a smell.
 
-**Visual richness:** Proactively reach for visuals. If `surf` CLI is available (`which surf`), generate images for title slide backgrounds and full-bleed slides via `surf gemini --generate-image`. Add SVG decorative accents, inline sparklines, mini-charts, and small Mermaid diagrams where they make the story more compelling. Visual-first, text-second.
-
-**Compositional variety:** Consecutive slides must vary their spatial approach. Alternate between centered, left-heavy, right-heavy, split, edge-aligned, and full-bleed. Three centered slides in a row means push one off-axis.
-
-Write to `~/.agent/diagrams/` and open the result in the browser.
+Write to `~/.agent/diagrams/` and open in the browser.

--- a/plugins/visual-explainer/commands/generate-visual-plan.md
+++ b/plugins/visual-explainer/commands/generate-visual-plan.md
@@ -1,107 +1,25 @@
 ---
-description: Generate a visual HTML implementation plan — detailed feature specification with state machines, code snippets, and edge cases
+description: Generate a visual implementation plan
 ---
-Load the visual-explainer skill, then generate a comprehensive visual implementation plan for `$@` as a self-contained HTML page.
 
-Follow the visual-explainer skill workflow. Read the reference template, CSS patterns, and mermaid theming references before generating. Use an editorial or blueprint aesthetic, but vary fonts and palette from previous diagrams.
+Load the visual-explainer skill and generate a self-contained HTML implementation plan for: $@
 
-**Data gathering phase** — understand the context before designing:
+## Research first
 
-1. **Parse the feature request.** Extract:
-   - The core problem being solved
-   - Desired user-facing behavior
-   - Any constraints or requirements mentioned
-   - Scope boundaries (what's explicitly out of scope)
+Read relevant repo files before planning. Identify entry points, existing patterns, affected modules, public APIs, tests, config/schema/data model, similar features, and constraints from README/CHANGELOG/docs.
 
-2. **Read the relevant codebase.** Identify:
-   - Files that will need modification
-   - Existing patterns to follow (code style, architecture, naming conventions)
-   - Related functionality that the feature should integrate with
-   - Types, interfaces, and APIs the feature must conform to
+## Required page sections
 
-3. **Understand the extension points.** Look for:
-   - Hook points, event systems, or plugin architectures
-   - Configuration options or flags
-   - Public APIs that might need extension
-   - Test patterns used in the codebase
+1. Goal and scope: what will change and what is intentionally out.
+2. Current state: short diagram/table of existing architecture.
+3. Proposed design: architecture/data/control flow, preferably Mermaid or hybrid cards.
+4. Implementation sequence: ordered phases with dependencies.
+5. File map: files to create/edit/delete and why.
+6. Interface/contracts: types, APIs, schemas, CLI flags, config, events.
+7. Risk and decision matrix: correctness, tests, migration, release, UX, security/privacy, performance.
+8. Test plan: unit/integration/e2e/edge cases mapped to files.
+9. Acceptance checklist: observable done criteria.
 
-4. **Check for prior art.** Search for:
-   - Similar features already implemented
-   - Related issues or discussions
-   - Existing code that can be reused or extended
+Use hierarchy: overview and architecture dominate; detailed file/test/reference sections stay compact or collapsible. Follow the skill’s Mermaid, table, overflow, and delivery rules.
 
-**Design phase** — work through the implementation before writing HTML:
-
-1. **State design.** What new state variables are needed? What existing state is affected? Draw the state machine if behavior has multiple modes.
-
-2. **API design.** What commands, functions, or endpoints are added? What are the signatures? What are the error cases?
-
-3. **Integration design.** How does this feature interact with existing functionality? What hooks or events are involved?
-
-4. **Edge cases.** Walk through unusual scenarios: concurrent operations, error conditions, boundary values, user mistakes.
-
-**Verification checkpoint** — before generating HTML, produce a structured fact sheet:
-- Every state variable (new and modified) with its type and purpose
-- Every function/command/API with its signature
-- Every file that needs modification with the specific changes
-- Every edge case with expected behavior
-- Every assumption about the codebase that the plan relies on
-Verify each against the code. If something cannot be verified, mark it as uncertain. This fact sheet is your source of truth during HTML generation.
-
-**Diagram structure** — the page should include:
-
-1. **Header** — feature name, one-line description, scope summary. *Visual treatment: use a distinctive header with monospace label ("Feature Plan", "Implementation Spec", etc.), large italic title, and muted subtitle. Set the tone for the page.*
-
-2. **The Problem** — side-by-side comparison panels showing current behavior vs. desired behavior. Use concrete examples, not abstract descriptions. Show what the user experiences or what the code does, step by step. *Visual treatment: two-column grid with rose-tinted "Before" header and sage-tinted "After" header. Numbered flow steps with arrows between them.*
-
-3. **State Machine** — Mermaid flowchart or stateDiagram showing the states and transitions. Label edges with the triggers (commands, events, conditions). *Wrap in `.mermaid-wrap` with zoom controls (+/−/reset/expand) and click-to-expand. Use `flowchart TD` instead of `stateDiagram-v2` if labels need special characters like colons or parentheses. Add explanatory caption below the diagram.*
-
-4. **State Variables** — card grid showing new state and existing state (if modified). Use code blocks with proper `white-space: pre-wrap`. *Visual treatment: two cards side-by-side, elevated depth, monospace labels.*
-
-5. **Modified Functions** — for each function that needs changes, show:
-   - Function name and file path
-   - Key code snippet (not full implementation — 10-20 lines showing the pattern)
-   - Explanation of what changed and why
-   *Visual treatment: file path as monospace dim text above code block, code in recessed card with accent-dim background.*
-
-6. **Commands / API** — table with command/function name, parameters, and behavior description. Use `<code>` for technical names. *Visual treatment: bordered table with sticky header, alternating row backgrounds.*
-
-7. **Edge Cases** — table listing scenarios and expected behaviors. Be thorough — include error conditions, concurrent operations, boundary values. *Visual treatment: same table style as Commands section.*
-
-8. **Test Requirements** — table or card grid showing test categories and specific tests to add. Group by: unit tests, integration tests, edge case tests. *Visual treatment: compact table with file references.*
-
-9. **File References** — table mapping files to the changes needed. Include file paths and brief descriptions. *Visual treatment: compact reference table, can use `<details>` if many files.*
-
-10. **Implementation Notes** — callout boxes for:
-    - Backward compatibility considerations (gold border)
-    - Critical implementation warnings (rose border)
-    - Performance considerations if relevant (amber border)
-    *Visual treatment: callout boxes with colored left borders, strong labels.*
-
-**Visual hierarchy:**
-- Sections 1-3 should dominate the viewport on load (hero depth for header, elevated for problem comparison and state machine)
-- Sections 4-6 are core implementation details (elevated cards, readable code blocks)
-- Sections 7-10 are reference material (flat or recessed depth, compact layout)
-
-**Typography and color:**
-- Pick a distinctive font pairing (not Inter/Roboto)
-- Use semantic accent colors: gold for primary accents, sage for "after"/success states, rose for "before"/warning states
-- Both light and dark themes must work
-
-**Optional hero image** — if `surf` CLI is available (`which surf`), consider generating a conceptual illustration that captures the feature's essence. Use for abstract concepts that benefit from visual metaphor. Skip for purely structural changes. Embed as base64 data URI using the `.hero-img-wrap` pattern from css-patterns.md.
-
-**Code block requirements:**
-- Always use `white-space: pre-wrap` and `word-break: break-word`
-- Include file path headers where relevant
-- Use syntax-appropriate highlighting via CSS classes if desired
-- Keep snippets focused — show the pattern, not the full implementation
-
-**Overflow prevention:**
-- Apply `min-width: 0` on all grid/flex children
-- Use `overflow-wrap: break-word` on all text containers
-- Never use `display: flex` on `<li>` for markers — use absolute positioning
-- Test tables with wide content don't overflow their container
-
-Write to `~/.agent/diagrams/` with a descriptive filename (e.g., `feature-name-plan.html`). Open the result in the browser. Tell the user the file path.
-
-Ultrathink.
+Write to `~/.agent/diagrams/` and open in browser.

--- a/plugins/visual-explainer/commands/generate-web-diagram.md
+++ b/plugins/visual-explainer/commands/generate-web-diagram.md
@@ -1,10 +1,9 @@
 ---
-description: Generate a beautiful standalone HTML diagram and open it in the browser
+description: Generate a standalone HTML diagram and open it in the browser
 ---
-Load the visual-explainer skill, then generate an HTML diagram for: $@
 
-Follow the visual-explainer skill workflow. Read the reference template and CSS patterns before generating. Pick a distinctive aesthetic that fits the content — vary fonts, palette, and layout style from previous diagrams.
+Load the visual-explainer skill and generate an HTML visual explainer for: $@
 
-If `surf` CLI is available (`which surf`), consider generating an AI illustration via `surf gemini --generate-image` when an image would genuinely enhance the page — a hero banner, conceptual illustration, or educational diagram that Mermaid can't express. Match the image style to the page's palette. Embed as base64 data URI. See css-patterns.md "Generated Images" for container styles. Skip images when the topic is purely structural or data-driven.
+Use the skill’s reference routing and final checklist. Pick a representation that fits the topic: Mermaid for connected flows/topologies; CSS cards for text-heavy explanations; tables for matrices; timelines for linear history.
 
-Write to `~/.agent/diagrams/` and open the result in the browser. In Pi package installs, this command is already an explicit visual request, so use `visual_explainer` with `action: "prepare"` first when the topic needs planning or context scouting, then use `action: "render"` as the final step with a basename-style filename and the complete HTML document.
+Write to `~/.agent/diagrams/` with a descriptive filename and open the result in the browser. In Pi package installs, this is an explicit visual request: use `visual_explainer.prepare` when planning/context scouting helps, then `visual_explainer.render` with the complete HTML.

--- a/plugins/visual-explainer/commands/plan-review.md
+++ b/plugins/visual-explainer/commands/plan-review.md
@@ -1,86 +1,32 @@
 ---
-description: Generate a visual HTML plan review — current codebase state vs. proposed implementation plan
+description: Compare an implementation plan against the current codebase
 ---
-Load the visual-explainer skill, then generate a comprehensive visual plan review as a self-contained HTML page, comparing the current codebase against a proposed implementation plan.
 
-Follow the visual-explainer skill workflow. Read the reference template, CSS patterns, and mermaid theming references before generating. Use a blueprint/editorial aesthetic with current-state vs. planned-state panels, but vary fonts and palette from previous diagrams.
+Load the visual-explainer skill and generate a self-contained HTML plan review.
 
-**Inputs:**
-- Plan file: `$1` (path to a markdown plan, spec, or RFC document)
-- Codebase: `$2` if provided, otherwise the current working directory
+## Inputs
 
-**Data gathering phase** — read and cross-reference these before generating:
+Use `$@` as the plan path or plan text. If no path is given, ask for the plan.
 
-1. **Read the plan file in full.** Extract:
-   - The problem statement and motivation
-   - Each proposed change (files to modify, new files, deletions)
-   - Rejected alternatives and their reasoning
-   - Any explicit scope boundaries or non-goals
+## Data gathering before HTML
 
-2. **Read every file the plan references.** For each file mentioned in the plan, read the current version in full. Also read files that import or depend on those files — the plan may not mention all ripple effects.
+Read the plan in full. Extract goals, assumptions, proposed files/functions/types, migrations, tests, rollout/release notes, and explicit risks. Read every referenced file, plus importers/dependents that may be affected. Use ripgrep for existing patterns, similar implementations, public API boundaries, config/schema files, and tests.
 
-3. **Map the blast radius.** From the codebase, identify:
-   - What imports/requires the files being changed (grep for import paths)
-   - What tests exist for the affected files (look for corresponding `.test.*` / `.spec.*` files)
-   - Config files, types, or schemas that might need updates
-   - Public API surface that callers depend on
+## Source verification
 
-4. **Cross-reference plan vs. code.** For each change the plan proposes, verify:
-   - Does the file/function/type the plan references actually exist in the current code?
-   - Does the plan's description of current behavior match what the code actually does?
-   - Are there implicit assumptions about code structure that don't hold?
+For each proposed change, verify whether referenced files/functions/types exist, whether current behavior matches the plan, what ripple effects are missing, and whether the proposed test coverage fits the current test style. Cite plan sections and file:line evidence.
 
-**Verification checkpoint** — before generating HTML, produce a structured fact sheet of every claim you will present in the review:
-- Every quantitative figure: file counts, estimated lines, function counts, test counts
-- Every function, type, and module name you will reference from both the plan and the codebase
-- Every behavior description: what the code currently does vs. what the plan proposes
-- For each, cite the source: the plan section or the file:line where you read it
-Verify each claim against the code and the plan. If something cannot be verified, mark it as uncertain rather than stating it as fact. This fact sheet is your source of truth during HTML generation — do not deviate from it.
+## Required page sections
 
-**Diagram structure** — the page should include:
+1. Plan summary: problem, core idea, scope.
+2. Accuracy verdict: correct, stale, risky, unsupported, missing.
+3. Current architecture: diagram of affected subsystem only.
+4. Proposed architecture: matching visual diff against current state.
+5. Gap/risk matrix: correctness, tests, API, data model, UX, security/privacy, performance, maintainability, release.
+6. File-by-file review: proposed edits, current reality, recommendation.
+7. Better plan: concrete corrections or simplifications.
+8. Decision: approve, revise, or reject with rationale.
 
-1. **Plan summary** — lead with the *intuition*: what problem does this plan solve, and what's the core insight behind the approach? Then the scope: how many files touched, estimated scale of changes, new modules or tests planned. A reader who only sees this section should understand the plan's essence. *Visual treatment: this is the visual anchor — use hero depth (larger type 20-24px, subtle accent-tinted background, more padding than other sections).*
+Use current-vs-planned visual language. Include responsive nav. Follow the skill’s Mermaid, overflow, and evidence rules.
 
-2. **Impact dashboard** — files to modify, files to create, files to delete, estimated lines added/removed, new test files planned, dependencies affected. Include a **completeness** indicator: whether the plan covers tests (green/red), docs updates (green/yellow/red), and migration/rollback (green/grey for N/A).
-
-3. **Current architecture** — Mermaid diagram of how the affected subsystem works *today*. Focus only on the parts the plan touches — don't diagram the entire codebase. Show the data flow, dependencies, and call paths that will change. Wrap in `.mermaid-wrap` with zoom controls (+/−/reset/expand buttons), Ctrl/Cmd+scroll zoom, click-and-drag panning, and click-to-expand (opens diagram full-size in new tab). See css-patterns.md "Mermaid Zoom Controls" for the full pattern including the `openMermaidInNewTab()` function. *Visual treatment: use matching Mermaid layout direction and node names as section 4 so the visual diff is obvious.*
-
-4. **Planned architecture** — Mermaid diagram of how the subsystem will work *after* the plan is implemented. Use the same node names and layout direction as the current architecture diagram so the differences are visually obvious. Same zoom controls and click-to-expand as section 3. *Highlight new nodes with a glow or accent border, removed nodes with strikethrough or reduced opacity, changed edges with a different stroke color.*
-
-5. **Change-by-change breakdown** — for each change in the plan, a side-by-side panel. Overflow prevention: apply `min-width: 0` on all grid/flex children and `overflow-wrap: break-word` on panels. Never use `display: flex` on `<li>` for marker characters — use absolute positioning instead (see css-patterns.md Overflow Protection).
-   - **Left (current):** what the code does now, with relevant snippets or function signatures
-   - **Right (planned):** what the plan proposes, with the plan's own code examples if provided
-   - **Rationale:** below each side-by-side panel, extract _why_ the plan chose this approach. Pull from the plan's reasoning, rejected alternatives section, or inline justifications. If the plan includes a "rejected alternatives" section, map those rejections to the specific changes they apply to. Flag changes where the plan says _what_ to do but not _why_ — these are pre-implementation cognitive debt.
-   - Flag any discrepancies where the plan's description of current behavior doesn't match the actual code
-
-6. **Dependency & ripple analysis** — *visual treatment: compact — consider `<details>` collapsed by default for pages with many sections.* What other code depends on the files being changed. Table or Mermaid graph showing callers, importers, and downstream effects the plan may not explicitly address. Color-code: covered by plan (green), not mentioned but likely affected (amber), definitely missed (red).
-
-7. **Risk assessment** — styled cards for:
-   - **Edge cases** the plan doesn't address
-   - **Assumptions** the plan makes about the codebase that should be verified
-   - **Ordering risks** if changes need to be applied in a specific sequence
-   - **Rollback complexity** if things go wrong
-   - **Cognitive complexity** — areas where the plan introduces non-obvious coupling, action-at-a-distance behavior, implicit ordering requirements, or contracts that exist only in the developer's memory. Distinct from bug risk — these are "you'll forget how this works in a month" risks. Each cognitive complexity flag gets a brief mitigation suggestion (e.g., "add a comment explaining the ordering requirement" or "consider a runtime assertion that validates the invariant"). Note: cognitive complexity flags belong here when they're about specific code patterns; broader concerns about the plan's overall approach (overengineering, lock-in, maintenance burden) belong in section 8's Ugly category.
-   - Each risk gets a severity indicator (low/medium/high)
-
-8. **Plan review** — structured Good/Bad/Ugly analysis of the plan itself:
-   - **Good**: Solid design decisions, things the plan gets right, well-reasoned tradeoffs
-   - **Bad**: Gaps in the plan — missing files, unaddressed edge cases, incorrect assumptions about current code
-   - **Ugly**: Subtle concerns — complexity being introduced, maintenance burden, things that will work initially but cause problems at scale
-   - **Questions**: Ambiguities that need the plan author's clarification before implementation begins
-   - Use styled cards with green/red/amber/blue left-border accents. Each item should reference specific plan sections and code files. If nothing to flag in a category, say "None found" rather than omitting the section.
-9. **Understanding gaps** — a closing dashboard that rolls up decision-rationale gaps from section 5 and cognitive complexity flags from section 7:
-   - Count of changes with clear rationale vs. missing rationale (visual bar chart or progress indicator)
-   - List of cognitive complexity flags with severity
-   - Explicit recommendations: "Before implementing, document the rationale for changes X and Y — the plan doesn't explain why these approaches were chosen over alternatives"
-   - This section makes cognitive debt visible _before_ the work starts, when it's cheapest to address.
-
-**Visual hierarchy**: Sections 1-4 should dominate the viewport on load (hero depth for summary, elevated for architecture diagrams). Sections 6+ are reference material and should feel lighter (flat or recessed depth, compact layout, collapsible where appropriate).
-
-**Optional illustrations** — if `surf` CLI is available (`which surf`), consider generating a conceptual illustration of the planned system via `surf gemini --generate-image` when it would help the reader visualize the change. Embed as base64 data URI. See css-patterns.md "Generated Images" for container styles. Skip if surf isn't available or the plan is purely structural.
-
-Include responsive section navigation. Use a current-vs-planned visual language throughout: blue/neutral for current state, green/purple for planned additions, amber for areas of concern, red for gaps or risks. Write to `~/.agent/diagrams/` and open in browser.
-
-Ultrathink.
-
-$@
+Write to `~/.agent/diagrams/` and open in browser.

--- a/plugins/visual-explainer/commands/project-recap.md
+++ b/plugins/visual-explainer/commands/project-recap.md
@@ -1,61 +1,28 @@
 ---
-description: Generate a visual HTML project recap — rebuild mental model of a project's current state, recent decisions, and cognitive debt hotspots
+description: Generate a visual project recap for context switching
 ---
-Load the visual-explainer skill, then generate a comprehensive visual project recap as a self-contained HTML page.
 
-Follow the visual-explainer skill workflow. Read the reference template, CSS patterns, and mermaid theming references before generating. Use a warm editorial or paper/ink aesthetic with muted blues and greens, but vary fonts and palette from previous diagrams.
+Load the visual-explainer skill and generate a self-contained HTML project recap.
 
-**Time window** — determine the recency window from `$1`:
-- Shorthand like `2w`, `30d`, `3m`: parse to git's `--since` format (`2w` → `"2 weeks ago"`, `30d` → `"30 days ago"`, `3m` → `"3 months ago"`)
-- If `$1` doesn't match a time pattern, treat it as free-form context and use the default window
-- No argument: default to `2w` (2 weeks)
+## Data gathering before HTML
 
-**Data gathering phase** — run these first to understand the project:
+Read project identity files (`README`, changelog, package/build files), top-level tree, current git status, recent commits, unmerged/stale branches, TODO/FIXME in recent files, progress/todo memory if present, and key entry points/source files. Focus on what a returning developer needs to rebuild the mental model.
 
-1. **Project identity.** Read `README.md`, `CHANGELOG.md`, `package.json` / `Cargo.toml` / `pyproject.toml` / `go.mod` for name, description, version, dependencies. Read the top-level file structure.
+## Verify before generating
 
-2. **Recent activity.** `git log --oneline --since=<window>` for commit history. `git log --stat --since=<window>` for file-level change scope. `git shortlog -sn --since=<window>` for contributor activity. Identify which areas of the codebase were most active.
+Cite command output or file:line evidence for project state, module/function/type names, recent activity, current blockers, and next-step claims. Do not fabricate momentum or rationale.
 
-3. **Current state.** Check for uncommitted changes (`git status`). Check for stale branches (`git branch --no-merged`). Look for TODO/FIXME comments in recently changed files. Read progress docs if they exist (`~/.agent/memory/{project}/progress.md`, `~/.pi/agent/memory/{project}/progress.md`, `.pi/todos/`, or similar).
+## Required page sections
 
-4. **Decision context.** Read recent commit messages for rationale. If running in the same session as recent work, mine the conversation history. Read any plan docs, RFCs, or ADRs in the project directory.
+1. Project identity: what this repo is, stack, entry points.
+2. Architecture snapshot: Mermaid or hybrid diagram of current conceptual modules.
+3. Recent activity: grouped narrative, not raw log.
+4. Current state: uncommitted work, branches, TODOs, known blockers.
+5. Mental model map: key modules, data flow, command/test/deploy paths.
+6. Risks and cognitive debt: hotspots and gotchas.
+7. Useful commands and files.
+8. Likely next steps, based only on evidence.
 
-5. **Architecture scan.** Read key source files to understand the module structure and dependencies. Focus on entry points, public API surface, and the files most frequently changed in the time window.
+Use responsive nav. Use compact reference tables for file maps and commands. Follow the skill’s Mermaid, overflow, and delivery rules.
 
-**Verification checkpoint** — before generating HTML, produce a structured fact sheet of every claim you will present in the recap:
-- Every quantitative figure: commit counts, file counts, line counts, branch counts
-- Every module, function, and type name you will reference
-- Every behavior and architecture description
-- For each, cite the source: the git command output that produced it, or the file:line where you read it
-Verify each claim against the code. If something cannot be verified, mark it as uncertain rather than stating it as fact. This fact sheet is your source of truth during HTML generation — do not deviate from it.
-
-**Optional hero image** — if `surf` CLI is available (`which surf`), generate a hero banner via `surf gemini --generate-image --aspect-ratio 16:9` that visually captures the project's identity or domain. Match the style to the page's palette. Embed as base64 data URI using the `.hero-img-wrap` pattern from css-patterns.md. Place above or just below the title. Skip if surf isn't available — the page should stand on its own.
-
-**Diagram structure** — the page should include:
-1. **Project identity** — not the README blurb. A *current-state* summary: what this project does, who uses it, what stage it's at (early dev, stable, actively shipping features). Include version, key dependencies, and the one-sentence "elevator pitch" for someone who forgot what they were building.
-2. **Architecture snapshot** — Mermaid diagram of the system as it exists today. Focus on the conceptual modules and their relationships, not every file. Label nodes with what they do, not just file names. Wrap in `.mermaid-wrap` with zoom controls (+/−/reset/expand buttons), Ctrl/Cmd+scroll zoom, click-and-drag panning, and click-to-expand (opens diagram full-size in new tab). See css-patterns.md "Mermaid Zoom Controls" for the full pattern including the `openMermaidInNewTab()` function. *Visual treatment: this is the visual anchor — use hero depth (elevated container, larger padding, subtle accent-tinted background). The rest of the page hangs off this diagram.*
-3. **Recent activity** — not raw git log. A human-readable narrative grouped by theme: feature work, bug fixes, refactors, infrastructure. Timeline visualization with the most significant changes called out. For each theme, a one-sentence summary of what happened and why it mattered.
-4. **Decision log** — key design decisions from the time window. Extracted from commit messages, conversation history, plan docs, progress docs. Each entry: what was decided, why, what was considered. This is the highest-value section for fighting cognitive debt — the reasoning that evaporates first.
-5. **State of things** — *visual treatment: use the KPI card pattern from css-patterns.md — large hero numbers for working/broken/blocked/in-progress counts, with color-coded trend indicators.* A dashboard of:
-   - What's working (stable, shipped, tested)
-   - What's in progress (uncommitted work, open branches, active TODOs)
-   - What's broken or degraded (known bugs, failing tests, tech debt items)
-   - What's blocked (waiting on external input, dependencies, decisions)
-6. **Mental model essentials** — the 5-10 things you need to hold in your head to work on this project effectively:
-   - Key invariants and contracts (what must always be true)
-   - Non-obvious coupling (things connected in ways you wouldn't guess from the file tree)
-   - Gotchas (common mistakes, easy-to-forget requirements, things that break silently)
-   - Naming conventions or patterns the codebase follows
-7. **Cognitive debt hotspots** — *visual treatment: use amber-tinted cards with severity indicators (colored left border: red for high, amber for medium, blue for low).* Areas where understanding is weakest:
-   - Code that changed recently but has no documented rationale
-   - Complex modules with no tests
-   - Areas where multiple people (or agents) made overlapping changes
-   - Files that are frequently modified but poorly understood
-   - Flag each with a severity and a concrete suggestion (e.g., "add a doc comment to `buildCoordinationInstructions` explaining the 4 coordination levels — this function is called from 3 places and the behavior is non-obvious")
-8. **Next steps** — inferred from recent activity, open TODOs, project trajectory. Not prescriptive — just "here's where the momentum was pointing when you left." Include any explicit next-step notes from progress docs or plan files.
-
-Include responsive section navigation. Use a warm, approachable visual language: muted blues and greens for architecture, amber callouts for cognitive debt hotspots, green/blue/amber/red for state-of-things status. Overflow prevention on any side-by-side or grid-based sections: apply `min-width: 0` on all grid/flex children and `overflow-wrap: break-word`. Never use `display: flex` on `<li>` for marker characters — use absolute positioning instead (see css-patterns.md Overflow Protection). Write to `~/.agent/diagrams/` and open in browser.
-
-Ultrathink.
-
-$@
+Write to `~/.agent/diagrams/` and open in browser.


### PR DESCRIPTION
This trims the visual-explainer skill and command prompts from 10,824 words to 2,131 words, which is a little over 80% less prompt text loaded by agents.

The idea came from Matt Pocock’s thread on no-op skill instructions: https://x.com/mattpocockuk/status/2069784839474032896

I kept the parts that actually steer behavior: when to render HTML, which references to read, Mermaid shell/zoom rules, table handling, slide navigation, diff review file maps, and the final quality checks. The removed text was mostly repeated explanation and long-form rationale that can live in the reference docs instead of the always-loaded skill and command prompts.
