### PR TITLE
Reader-first: math-truncation fix, doc meta, and SlideEngine navigation

### DIFF
--- a/docs/MANAGED-FORK.md
+++ b/docs/MANAGED-FORK.md
@@ -1,0 +1,48 @@
+# Managed fork workflow
+
+This is a **managed fork** of `nicobailon/visual-explainer`. It carries local
+customizations (a standard self-contained favicon, house-style notes) on top of
+upstream, and stays updatable.
+
+## Philosophy: control over automatic
+
+Updates are **on-demand, not automatic**. Nothing pulls upstream behind your
+back — so your local modifications and pinned behavior are never disturbed by a
+surprise merge. When you *do* want to update, it's one command, and a pi agent
+resolves any conflicts with full repository context.
+
+If a session is already current, everything just loads normally with zero work.
+
+## Remotes
+
+| Remote     | Points at                          | Role                         |
+|------------|------------------------------------|------------------------------|
+| `origin`   | `zereraz/visual-explainer`         | your fork (your commits)     |
+| `upstream` | `nicobailon/visual-explainer`      | the original project         |
+
+## Updating
+
+From this clone (`~/Code/Zereraz/visual-explainer`):
+
+```bash
+bash scripts/update-fork.sh --check     # status only; never modifies
+bash scripts/update-fork.sh --apply     # fetch + merge upstream + push + pi update
+# if conflicts (exit 20): resolve files, then:
+bash scripts/update-fork.sh --continue
+```
+
+Or, inside pi, just run the command (loaded with this plugin):
+
+```
+/update-visual-explainer
+```
+
+The command checks first, applies if behind, and if a merge conflict occurs the
+agent resolves it — **keeping both** upstream's new behavior and our additive
+customizations — then commits, pushes, and refreshes the install.
+
+## Making your own changes
+
+Commit directly on `main` (small tweaks) or via a feature branch + PR to your
+own fork. Because our changes are additive, upstream merges are usually clean.
+`scripts/update-fork.sh` verifies the favicon customizations survived each update.

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -19,6 +19,17 @@ Generate self-contained HTML pages that explain systems, code changes, plans, da
 - Write files to `~/.agent/diagrams/` or the explicit eval output path. Use descriptive filenames.
 - Open generated pages in the browser when running normally. In Pi package installs, use `visual_explainer` with `prepare` for planning/context and `render` only after the complete HTML document exists.
 - The final page must be a complete self-contained HTML document, including embedded CSS and any needed JS.
+- Always include the standard self-contained data-URI favicon immediately after `</title>` (see "Favicon" below). Never leave a page without a favicon.
+
+## Favicon
+
+Every generated page must include this exact self-contained data-URI favicon, placed immediately after the `</title>` tag. It needs no external file and is a small node-graph glyph that matches the dark/accent palette:
+
+```html
+<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNyIgZmlsbD0iIzBmMTcyOSIvPjxjaXJjbGUgY3g9IjkiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjZDRhNzNhIi8+PGNpcmNsZSBjeD0iMjMiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjNjBhNWZhIi8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyMi41IiByPSIzIiBmaWxsPSIjNGFkZTgwIi8+PHBhdGggZD0iTTkgMTAuNSBMMTYgMjIuNSBMMjMgMTAuNSIgc3Ryb2tlPSIjZDRhNzNhIiBzdHJva2Utd2lkdGg9IjEuNyIgZmlsbD0ibm9uZSIgb3BhY2l0eT0iMC43NSIvPjwvc3ZnPg==">
+```
+
+If math is rendered with KaTeX, escape `<` as `&lt;` inside `$$...$$` (e.g. `y_{&lt;t}`); a bare `<` makes the HTML parser truncate the formula.
 
 ## Reference routing
 
@@ -92,6 +103,7 @@ If `surf` is available, generated images may be embedded as base64 for hero bann
 Before delivery, verify:
 
 - complete HTML document;
+- standard favicon `<link rel="icon">` present immediately after `</title>`;
 - output written to the requested path;
 - no console errors when opened;
 - no horizontal overflow at normal desktop width;

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -94,6 +94,16 @@ Use slides only when explicitly requested or when a command asks for slides. Sli
 - Do not drop content to fit a fixed slide count. Add slides instead.
 - Use the 10 slide types from `slide-patterns.md`: Title, Section Divider, Content, Split, Diagram, Dashboard, Table, Code, Quote, Full-Bleed.
 
+## Reader-first defaults (pages are made to be read and re-read)
+
+The primary use is a reader consuming the page, often over multiple sittings. Build for that:
+
+- **Navigation**: ship the upgraded `SlideEngine` from `slide-deck.html` — it adds deep-link hashes (`#slide-7`), resume-where-you-left-off (localStorage), reading percent in the counter, an outline overlay (press `O`), and a keyboard help panel (press `?`). Don't ship a stripped engine.
+- **Comprehension**: open each section with its one-line takeaway, then expand (TL;DR-first). End a multi-section page with a short "what to remember" recap.
+- **Glossary**: wrap domain jargon in `<abbr title="one-line definition">term</abbr>` so a reader can hover/tap for meaning without leaving the page.
+- **Don't gate content on motion**: every slide must be fully readable even if its animation never plays; animations enhance, never reveal essential text.
+- **Accessibility**: don't rely on color alone (pair with shape/label); respect `prefers-reduced-motion`; keep body text ≥ 16px with generous line-height; ensure keyboard nav reaches everything.
+
 ## Optional generated images
 
 If `surf` is available, generated images may be embedded as base64 for hero banners, conceptual illustrations, or educational visuals. Skip images for data-heavy, structural, or Mermaid/CSS-suitable content. Pages must stand on CSS, typography, and diagrams without images.
@@ -104,6 +114,8 @@ Before delivery, verify:
 
 - complete HTML document;
 - standard favicon `<link rel="icon">` present immediately after `</title>`;
+- decks use the upgraded SlideEngine (outline `O`, help `?`, deep-link + resume, reading %);
+- each slide readable with animations disabled; no content depends on motion;
 - output written to the requested path;
 - no console errors when opened;
 - no horizontal overflow at normal desktop width;

--- a/plugins/visual-explainer/commands/update-visual-explainer.md
+++ b/plugins/visual-explainer/commands/update-visual-explainer.md
@@ -1,0 +1,28 @@
+---
+name: update-visual-explainer
+description: Sync this visual-explainer fork with upstream, preserving local customizations; an agent resolves any merge conflicts.
+---
+
+Update the managed `visual-explainer` fork. This is **on-demand** — only run because the user asked.
+
+Managed clone location (try in order; use the first that exists):
+- `~/Code/Zereraz/visual-explainer`
+- the installed package dir: `~/.pi/agent/git/github.com/zereraz/visual-explainer`
+
+Steps:
+
+1. **Check first.** Run `bash scripts/update-fork.sh --check` from the managed clone.
+   - Exit `0` → already up to date. Tell the user "already current (fork is N commits ahead with your customizations)" and stop.
+   - Exit `10` → behind upstream; show the listed upstream commits, then continue.
+
+2. **Apply.** Run `bash scripts/update-fork.sh --apply`.
+   - Exit `0` → clean merge, pushed to the fork, and `pi update` refreshed the install. Report what upstream commits were merged and confirm the local customizations (favicon / house-style) survived. Done.
+   - Exit `20` → **merge conflict**. Do NOT abandon. Resolve it:
+     a. Read each conflicted file (`git diff --name-only --diff-filter=U`).
+     b. For each conflict, **keep the intent of BOTH sides**: upstream's new behavior AND our customizations (the favicon injection in `extension.ts`, favicon lines in `templates/*.html` and `SKILL.md`, the KaTeX `&lt;` note). Our changes are additive — prefer integrating, not discarding.
+     c. After resolving every file, run `bash scripts/update-fork.sh --continue` to commit, push, and reinstall.
+   - Exit `2` → precondition failure (dirty tree / wrong branch). Read the message, fix it (commit/stash local work, or `git checkout main`), then retry.
+
+3. **Verify** after success: confirm `grep -c ensureFavicon plugins/visual-explainer/extension.ts` is non-zero and the 4 templates still contain `rel="icon"`. If a customization was lost in the merge, re-apply it and amend.
+
+Report concisely: what changed upstream, whether conflicts occurred, how they were resolved, and that customizations are intact. $@

--- a/plugins/visual-explainer/extension.ts
+++ b/plugins/visual-explainer/extension.ts
@@ -128,6 +128,17 @@ function outputFilename(input: string) {
   return /\.html?$/i.test(raw) ? raw : `${raw}.html`;
 }
 
+const STANDARD_FAVICON =
+  '<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNyIgZmlsbD0iIzBmMTcyOSIvPjxjaXJjbGUgY3g9IjkiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjZDRhNzNhIi8+PGNpcmNsZSBjeD0iMjMiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjNjBhNWZhIi8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyMi41IiByPSIzIiBmaWxsPSIjNGFkZTgwIi8+PHBhdGggZD0iTTkgMTAuNSBMMTYgMjIuNSBMMjMgMTAuNSIgc3Ryb2tlPSIjZDRhNzNhIiBzdHJva2Utd2lkdGg9IjEuNyIgZmlsbD0ibm9uZSIgb3BhY2l0eT0iMC43NSIvPjwvc3ZnPg==">';
+
+// Guarantees the house-style favicon is present, regardless of what the agent emitted.
+function ensureFavicon(html: string): string {
+  if (/<link\b[^>]*rel\s*=\s*["']?(?:shortcut\s+)?icon/i.test(html)) return html;
+  if (/<\/title>/i.test(html)) return html.replace(/<\/title>/i, `</title>\n${STANDARD_FAVICON}`);
+  if (/<head[^>]*>/i.test(html)) return html.replace(/<head[^>]*>/i, (m) => `${m}\n${STANDARD_FAVICON}`);
+  return html;
+}
+
 function assertHtmlDocument(html: string) {
   const trimmed = html.trim();
   if (!trimmed) throw new Error("html is required");
@@ -276,7 +287,8 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
   }
 
   signal?.throwIfAborted();
-  writeFileSync(outputPath, params.html, "utf8");
+  const finalHtml = ensureFavicon(params.html);
+  writeFileSync(outputPath, finalHtml, "utf8");
 
   signal?.throwIfAborted();
 

--- a/plugins/visual-explainer/extension.ts
+++ b/plugins/visual-explainer/extension.ts
@@ -139,6 +139,30 @@ function ensureFavicon(html: string): string {
   return html;
 }
 
+// Reader-safety: inside $$...$$ display math, escape < and > so the HTML
+// parser doesn't treat e.g. y_{<t} as a tag and silently truncate the formula.
+// KaTeX decodes entities, so this is semantically lossless. Scoped to $$ (very
+// unlikely to false-match) and skips already-escaped content.
+function fixDisplayMath(html: string): string {
+  return html.replace(/\$\$([\s\S]*?)\$\$/g, (_m, inner: string) => {
+    const fixed = inner.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return `$$${fixed}$$`;
+  });
+}
+
+// Reader-safety: a complete, well-formed document for any browser/offline read.
+function ensureDocMeta(html: string): string {
+  let out = html;
+  if (!/<html[^>]*\blang=/i.test(out)) out = out.replace(/<html\b/i, '<html lang="en"');
+  if (/<head[^>]*>/i.test(out)) {
+    if (!/<meta[^>]+name=["']viewport/i.test(out))
+      out = out.replace(/<head[^>]*>/i, (m) => `${m}\n<meta name="viewport" content="width=device-width, initial-scale=1.0">`);
+    if (!/<meta[^>]+name=["']theme-color/i.test(out))
+      out = out.replace(/<head[^>]*>/i, (m) => `${m}\n<meta name="theme-color" content="#0f1729">`);
+  }
+  return out;
+}
+
 function assertHtmlDocument(html: string) {
   const trimmed = html.trim();
   if (!trimmed) throw new Error("html is required");
@@ -287,7 +311,8 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
   }
 
   signal?.throwIfAborted();
-  const finalHtml = ensureFavicon(params.html);
+  // Reader-safety pipeline: fix truncating math, complete the doc head, guarantee favicon.
+  const finalHtml = ensureFavicon(ensureDocMeta(fixDisplayMath(params.html)));
   writeFileSync(outputPath, finalHtml, "utf8");
 
   signal?.throwIfAborted();

--- a/plugins/visual-explainer/templates/architecture.html
+++ b/plugins/visual-explainer/templates/architecture.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Architecture Diagram — Reference Template</title>
+<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNyIgZmlsbD0iIzBmMTcyOSIvPjxjaXJjbGUgY3g9IjkiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjZDRhNzNhIi8+PGNpcmNsZSBjeD0iMjMiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjNjBhNWZhIi8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyMi41IiByPSIzIiBmaWxsPSIjNGFkZTgwIi8+PHBhdGggZD0iTTkgMTAuNSBMMTYgMjIuNSBMMjMgMTAuNSIgc3Ryb2tlPSIjZDRhNzNhIiBzdHJva2Utd2lkdGg9IjEuNyIgZmlsbD0ibm9uZSIgb3BhY2l0eT0iMC43NSIvPjwvc3ZnPg==">
 <!--
   Reference template for the visual-explainer skill: CSS Grid architecture layout.
   Warm terracotta/sage palette — distinctly different from the teal (mermaid)

--- a/plugins/visual-explainer/templates/data-table.html
+++ b/plugins/visual-explainer/templates/data-table.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Requirements Audit — Reference Template</title>
+<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNyIgZmlsbD0iIzBmMTcyOSIvPjxjaXJjbGUgY3g9IjkiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjZDRhNzNhIi8+PGNpcmNsZSBjeD0iMjMiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjNjBhNWZhIi8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyMi41IiByPSIzIiBmaWxsPSIjNGFkZTgwIi8+PHBhdGggZD0iTTkgMTAuNSBMMTYgMjIuNSBMMjMgMTAuNSIgc3Ryb2tlPSIjZDRhNzNhIiBzdHJva2Utd2lkdGg9IjEuNyIgZmlsbD0ibm9uZSIgb3BhY2l0eT0iMC43NSIvPjwvc3ZnPg==">
 <!--
   Reference template for the visual-explainer skill: data tables.
   Rose/cranberry palette — distinctly different from terracotta (architecture)

--- a/plugins/visual-explainer/templates/mermaid-flowchart.html
+++ b/plugins/visual-explainer/templates/mermaid-flowchart.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>CI/CD Pipeline — Reference Template</title>
+<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNyIgZmlsbD0iIzBmMTcyOSIvPjxjaXJjbGUgY3g9IjkiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjZDRhNzNhIi8+PGNpcmNsZSBjeD0iMjMiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjNjBhNWZhIi8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyMi41IiByPSIzIiBmaWxsPSIjNGFkZTgwIi8+PHBhdGggZD0iTTkgMTAuNSBMMTYgMjIuNSBMMjMgMTAuNSIgc3Ryb2tlPSIjZDRhNzNhIiBzdHJva2Utd2lkdGg9IjEuNyIgZmlsbD0ibm9uZSIgb3BhY2l0eT0iMC43NSIvPjwvc3ZnPg==">
 <!--
   Reference template for the visual-explainer skill: Mermaid diagrams.
   Teal/cyan palette — distinctly different from terracotta (architecture)

--- a/plugins/visual-explainer/templates/slide-deck.html
+++ b/plugins/visual-explainer/templates/slide-deck.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>API Gateway Redesign — Reference Slide Deck</title>
+<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNyIgZmlsbD0iIzBmMTcyOSIvPjxjaXJjbGUgY3g9IjkiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjZDRhNzNhIi8+PGNpcmNsZSBjeD0iMjMiIGN5PSIxMC41IiByPSIzIiBmaWxsPSIjNjBhNWZhIi8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyMi41IiByPSIzIiBmaWxsPSIjNGFkZTgwIi8+PHBhdGggZD0iTTkgMTAuNSBMMTYgMjIuNSBMMjMgMTAuNSIgc3Ryb2tlPSIjZDRhNzNhIiBzdHJva2Utd2lkdGg9IjEuNyIgZmlsbD0ibm9uZSIgb3BhY2l0eT0iMC43NSIvPjwvc3ZnPg==">
 <!--
   Reference template for the visual-explainer skill: slide decks.
   Midnight Editorial preset — deep navy, serif display, warm gold accents.

--- a/plugins/visual-explainer/templates/slide-deck.html
+++ b/plugins/visual-explainer/templates/slide-deck.html
@@ -863,52 +863,95 @@ graph LR
   function openMermaidInNewTab(w){var svg=w.querySelector('.mermaid svg');if(!svg)return;var clone=svg.cloneNode(true);clone.style.zoom='';clone.style.transform='';var styles=getComputedStyle(document.documentElement);var bg=styles.getPropertyValue('--bg').trim()||'#ffffff';var html='<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Diagram</title><style>body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:'+bg+';padding:40px;box-sizing:border-box}svg{max-width:100%;max-height:90vh;height:auto}</style></head><body>'+clone.outerHTML+'</body></html>';window.open(URL.createObjectURL(new Blob([html],{type:'text/html'})),'_blank');}
   document.querySelectorAll('.mermaid-wrap').forEach(function(w){w.addEventListener('wheel',function(e){if(!e.ctrlKey&&!e.metaKey)return;e.preventDefault();var t=w.querySelector('.mermaid');var c=parseFloat(t.dataset.zoom||INITIAL_ZOOM);var f=e.deltaY<0?1.1:0.9;var n=Math.min(Math.max(c*f,0.5),5);t.dataset.zoom=n;t.style.zoom=n;},{passive:false});var sX,sY,sL,sT,sTime,didPan;w.addEventListener('mousedown',function(e){if(e.target.closest('.zoom-controls'))return;w.classList.add('is-panning');sX=e.clientX;sY=e.clientY;sL=w.scrollLeft;sT=w.scrollTop;sTime=Date.now();didPan=false;});window.addEventListener('mousemove',function(e){if(!w.classList.contains('is-panning'))return;var dx=e.clientX-sX,dy=e.clientY-sY;if(Math.abs(dx)>5||Math.abs(dy)>5)didPan=true;w.scrollLeft=sL-dx;w.scrollTop=sT-dy;});window.addEventListener('mouseup',function(){if(!w.classList.contains('is-panning'))return;w.classList.remove('is-panning');if(!didPan&&Date.now()-sTime<300)openMermaidInNewTab(w);});});
 
-  // SlideEngine
+  // SlideEngine — reader-first: deep-link + resume, outline (O), help (?), reading %.
   function SlideEngine(){
     this.deck=document.querySelector('.deck');
     this.slides=[].slice.call(document.querySelectorAll('.slide'));
     this.current=0;
     this.total=this.slides.length;
+    this.storeKey='ve:'+location.pathname;
     this.buildChrome();
     this.bindEvents();
     this.observe();
+    this.restore();
     this.update();
   }
+  SlideEngine.prototype.titleOf=function(i){
+    var s=this.slides[i];var el=s.querySelector('.slide__display,.slide__heading,blockquote,.slide__kpi-label');
+    var t=el?el.textContent.trim().replace(/\s+/g,' '):''; if(!t){var n=s.querySelector('.slide__number');t=n?'Section '+n.textContent.trim():'Slide '+(i+1);} return t.length>54?t.slice(0,52)+'\u2026':t;
+  };
   SlideEngine.prototype.buildChrome=function(){
+    var self=this;
     var bar=document.createElement('div');bar.className='deck-progress';document.body.appendChild(bar);this.bar=bar;
-    var dots=document.createElement('div');dots.className='deck-dots';var self=this;
-    this.slides.forEach(function(_,i){var d=document.createElement('button');d.className='deck-dot';d.title='Slide '+(i+1);d.onclick=function(){self.goTo(i);};dots.appendChild(d);});
+    var dots=document.createElement('div');dots.className='deck-dots';
+    this.slides.forEach(function(_,i){var d=document.createElement('button');d.className='deck-dot';d.title=self.titleOf(i);d.onclick=function(){self.goTo(i);};dots.appendChild(d);});
     document.body.appendChild(dots);this.dots=[].slice.call(dots.children);
     var ctr=document.createElement('div');ctr.className='deck-counter';document.body.appendChild(ctr);this.counter=ctr;
-    var hints=document.createElement('div');hints.className='deck-hints';hints.textContent='\u2190 \u2192 or scroll to navigate';document.body.appendChild(hints);this.hints=hints;
-    this.hintTimer=setTimeout(function(){hints.classList.add('faded');},4000);
+    var hints=document.createElement('div');hints.className='deck-hints';hints.textContent='\u2190 \u2192 \u00b7 O outline \u00b7 ? help';document.body.appendChild(hints);this.hints=hints;
+    this.hintTimer=setTimeout(function(){hints.classList.add('faded');},4500);
+    // overlay (outline + help share one panel)
+    var ov=document.createElement('div');ov.setAttribute('style','position:fixed;inset:0;z-index:200;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);backdrop-filter:blur(3px)');
+    var panel=document.createElement('div');panel.setAttribute('role','dialog');panel.setAttribute('aria-label','Outline');
+    panel.setAttribute('style','max-height:80vh;overflow:auto;width:min(560px,86vw);background:var(--surface,#162040);color:var(--text,#e8e4d8);border:1px solid var(--border-bright,rgba(200,180,140,.16));border-radius:14px;padding:18px 14px;font-family:var(--font-mono,monospace)');
+    ov.appendChild(panel);document.body.appendChild(ov);this.ov=ov;this.panel=panel;
+    ov.addEventListener('click',function(e){if(e.target===ov)self.closeOverlay();});
   };
+  SlideEngine.prototype.renderOutline=function(){
+    var self=this;var h='<div style="font-size:12px;letter-spacing:1px;text-transform:uppercase;opacity:.6;margin:2px 8px 12px">Outline</div>';
+    this.slides.forEach(function(_,i){
+      var act=i===self.current;
+      h+='<button data-i="'+i+'" style="display:flex;gap:10px;width:100%;text-align:left;border:none;cursor:pointer;background:'+(act?'var(--accent-dim,rgba(212,167,58,.1))':'transparent')+';color:inherit;padding:8px 10px;border-radius:8px;font-family:inherit;font-size:13px;line-height:1.3"><span style="opacity:.5;min-width:22px">'+(i+1)+'</span><span style="'+(act?'color:var(--accent,#d4a73a)':'')+'">'+self.titleOf(i).replace(/[<>&]/g,function(c){return{'<':'&lt;','>':'&gt;','&':'&amp;'}[c];})+'</span></button>';
+    });
+    this.panel.innerHTML=h;
+    [].slice.call(this.panel.querySelectorAll('button')).forEach(function(b){b.onclick=function(){self.goTo(+b.getAttribute('data-i'));self.closeOverlay();};});
+  };
+  SlideEngine.prototype.renderHelp=function(){
+    this.panel.innerHTML='<div style="font-size:12px;letter-spacing:1px;text-transform:uppercase;opacity:.6;margin:2px 8px 14px">Keyboard</div>'+
+      [['\u2192 / \u2193 / Space','next'],['\u2190 / \u2191','previous'],['Home / End','first / last'],['O','outline'],['? ','this help'],['Esc','close']].map(function(r){
+        return '<div style="display:flex;justify-content:space-between;padding:7px 10px;font-size:13px"><span style="opacity:.7">'+r[1]+'</span><kbd style="background:var(--surface2,#1d2b52);border-radius:5px;padding:2px 8px">'+r[0]+'</kbd></div>';}).join('');
+  };
+  SlideEngine.prototype.openOverlay=function(mode){this.ov.style.display='flex';mode==='help'?this.renderHelp():this.renderOutline();};
+  SlideEngine.prototype.closeOverlay=function(){this.ov.style.display='none';};
   SlideEngine.prototype.bindEvents=function(){
     var self=this;
     document.addEventListener('keydown',function(e){
       if(e.target.closest('.mermaid-wrap,.table-scroll,.code-scroll,input,textarea,[contenteditable]'))return;
+      if(e.key==='Escape'){self.closeOverlay();return;}
+      var open=self.ov.style.display==='flex';
+      if(e.key==='o'||e.key==='O'){e.preventDefault();open?self.closeOverlay():self.openOverlay('outline');return;}
+      if(e.key==='?'){e.preventDefault();open?self.closeOverlay():self.openOverlay('help');return;}
+      if(open)return;
       if(['ArrowDown','ArrowRight',' ','PageDown'].indexOf(e.key)>-1){e.preventDefault();self.next();}
       else if(['ArrowUp','ArrowLeft','PageUp'].indexOf(e.key)>-1){e.preventDefault();self.prev();}
       else if(e.key==='Home'){e.preventDefault();self.goTo(0);}
       else if(e.key==='End'){e.preventDefault();self.goTo(self.total-1);}
       self.fadeHints();
     });
+    window.addEventListener('hashchange',function(){var i=self.fromHash();if(i!=null&&i!==self.current)self.goTo(i);});
     var tY;
     this.deck.addEventListener('touchstart',function(e){tY=e.touches[0].clientY;},{passive:true});
     this.deck.addEventListener('touchend',function(e){var dy=tY-e.changedTouches[0].clientY;if(Math.abs(dy)>50){dy>0?self.next():self.prev();}});
+  };
+  SlideEngine.prototype.fromHash=function(){var m=/^#(?:slide-)?(\d+)$/.exec(location.hash);if(!m)return null;var i=(+m[1])-1;return(i>=0&&i<this.total)?i:null;};
+  SlideEngine.prototype.restore=function(){
+    var i=this.fromHash();
+    if(i==null){try{var s=localStorage.getItem(this.storeKey);if(s!=null){var j=+s;if(j>0&&j<this.total)i=j;}}catch(e){}}
+    if(i!=null&&i>0){var self=this;this.current=i;setTimeout(function(){self.slides[i].scrollIntoView();},60);}
   };
   SlideEngine.prototype.observe=function(){
     var self=this;
     var obs=new IntersectionObserver(function(entries){entries.forEach(function(entry){if(entry.isIntersecting){entry.target.classList.add('visible');self.current=self.slides.indexOf(entry.target);self.update();}});},{threshold:0.5});
     this.slides.forEach(function(s){obs.observe(s);});
   };
-  SlideEngine.prototype.goTo=function(i){this.slides[Math.max(0,Math.min(i,this.total-1))].scrollIntoView({behavior:'smooth'});};
+  SlideEngine.prototype.goTo=function(i){i=Math.max(0,Math.min(i,this.total-1));this.slides[i].scrollIntoView({behavior:'smooth'});};
   SlideEngine.prototype.next=function(){if(this.current<this.total-1)this.goTo(this.current+1);};
   SlideEngine.prototype.prev=function(){if(this.current>0)this.goTo(this.current-1);};
   SlideEngine.prototype.update=function(){
-    this.bar.style.width=((this.current+1)/this.total*100)+'%';
-    var c=this.current;this.dots.forEach(function(d,i){d.classList.toggle('active',i===c);});
-    this.counter.textContent=(this.current+1)+' / '+this.total;
+    var c=this.current,pct=Math.round((c+1)/this.total*100);
+    this.bar.style.width=pct+'%';
+    this.dots.forEach(function(d,i){d.classList.toggle('active',i===c);});
+    this.counter.textContent=(c+1)+' / '+this.total+' \u00b7 '+pct+'%';
+    try{history.replaceState(null,'','#slide-'+(c+1));localStorage.setItem(this.storeKey,String(c));}catch(e){}
   };
   SlideEngine.prototype.fadeHints=function(){clearTimeout(this.hintTimer);this.hints.classList.add('faded');};
 </script>

--- a/scripts/update-fork.sh
+++ b/scripts/update-fork.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Managed-fork updater for visual-explainer.
+#
+# Keeps this fork (origin = your fork) in sync with the original project
+# (upstream = nicobailon/visual-explainer) while preserving your own commits
+# (favicon, house-style, local tweaks). On-demand by design — nothing here
+# runs automatically; invoke it yourself or via the /update-visual-explainer
+# command, which lets a pi agent resolve conflicts with full context.
+#
+# Exit codes (so an agent can branch on them):
+#   0  = up to date OR update applied cleanly
+#   10 = behind upstream (only with --check; no changes made)
+#   20 = merge conflict — working tree left dirty for an agent to resolve
+#   2  = precondition failure (dirty tree, missing remote, etc.)
+#
+# Usage:
+#   update-fork.sh --check       # report status only, never modify
+#   update-fork.sh --apply       # fetch, merge upstream, push, reinstall  (default)
+#   update-fork.sh --continue    # after conflicts are resolved: commit, push, reinstall
+set -euo pipefail
+
+PKG="git:github.com/zereraz/visual-explainer"   # change if your fork lives elsewhere
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+say() { printf '\033[1;33m• %s\033[0m\n' "$*"; }
+err() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; }
+ok()  { printf '\033[1;32m✓ %s\033[0m\n' "$*"; }
+
+mode="${1:---apply}"
+
+require_remotes() {
+  git remote get-url origin   >/dev/null 2>&1 || { err "no 'origin' remote (your fork)"; exit 2; }
+  git remote get-url upstream >/dev/null 2>&1 || {
+    say "adding 'upstream' = nicobailon/visual-explainer"
+    git remote add upstream git@github.com:nicobailon/visual-explainer.git
+  }
+}
+
+reinstall() {
+  if command -v pi >/dev/null 2>&1; then
+    say "refreshing installed package via 'pi update'"
+    pi update "$PKG" || pi install "$PKG"
+    ok "package refreshed"
+  else
+    say "pi CLI not found — skipping reinstall (push is done; run 'pi update $PKG' later)"
+  fi
+}
+
+case "$mode" in
+  --check)
+    require_remotes
+    git fetch --quiet upstream main
+    behind=$(git rev-list --count HEAD..upstream/main)
+    ahead=$(git rev-list --count upstream/main..HEAD)
+    if [ "$behind" -eq 0 ]; then
+      ok "up to date with upstream (your fork is $ahead commit(s) ahead — your customizations)"
+      exit 0
+    fi
+    say "behind upstream by $behind commit(s); your fork is $ahead ahead"
+    git --no-pager log --oneline HEAD..upstream/main | sed 's/^/   upstream: /'
+    exit 10
+    ;;
+
+  --apply)
+    require_remotes
+    if [ -n "$(git status --porcelain)" ]; then
+      err "working tree is dirty — commit or stash first"; git status --short; exit 2
+    fi
+    branch="$(git branch --show-current)"
+    [ "$branch" = "main" ] || { err "expected to be on 'main' (on '$branch')"; exit 2; }
+
+    git fetch --quiet upstream main
+    behind=$(git rev-list --count HEAD..upstream/main)
+    if [ "$behind" -eq 0 ]; then ok "already up to date — nothing to do"; exit 0; fi
+
+    say "merging upstream/main ($behind new commit(s)) into main, keeping your commits"
+    if git merge --no-edit upstream/main; then
+      ok "clean merge"
+      git push origin main
+      ok "pushed to your fork"
+      reinstall
+      exit 0
+    else
+      err "merge conflict — NOT pushing. Resolve, then run: $0 --continue"
+      echo "conflicted files:"; git diff --name-only --diff-filter=U | sed 's/^/   /'
+      exit 20
+    fi
+    ;;
+
+  --continue)
+    require_remotes
+    if git diff --name-only --diff-filter=U | grep -q .; then
+      err "unresolved conflicts remain:"; git diff --name-only --diff-filter=U | sed 's/^/   /'; exit 20
+    fi
+    say "committing resolved merge"
+    git add -A
+    git commit --no-edit || say "nothing to commit (merge may already be committed)"
+    git push origin main
+    ok "pushed to your fork"
+    reinstall
+    exit 0
+    ;;
+
+  *)
+    err "unknown mode '$mode'"; grep -A12 '^# Usage:' "$0" | sed 's/^# \{0,1\}//'; exit 2 ;;
+esac


### PR DESCRIPTION
Improves the *reading/consuming* experience and hardens render.

**render (extension.ts)** — auto-applied, idempotent, lossless:
- `fixDisplayMath()` escapes `<`/`>` inside `$$...$$` so the HTML parser can't truncate formulas like `y_{<t}` (KaTeX decodes the entities back). Fixes a recurring silent-failure.
- `ensureDocMeta()` injects `lang`, viewport, and `theme-color` when missing.

**SlideEngine (slide-deck.html)** — for pages read over multiple sittings:
- deep-link hashes (`#slide-N`) + back/forward nav
- resume where you left off (localStorage)
- reading percent in the counter
- outline overlay (`O`) with clickable slide titles
- keyboard help panel (`?`)

**SKILL.md** — reader-first defaults (TL;DR-first, recap, `<abbr>` glossary, no motion-gated content, a11y) + checklist.

All additive; no API change.