### PR TITLE
fix: correct changelog ordering, add node_modules to gitignore, button types + symlink check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,14 @@ Based on PR #25 by [@peak-flow](https://github.com/peak-flow), with additional m
 - Updated `SKILL.md` to explicitly mention the click-to-expand feature and expand button so agents include it when generating pages
 - Updated all prompt templates (`diff-review.md`, `plan-review.md`, `project-recap.md`, `generate-visual-plan.md`) to specify the expand button and click-to-expand functionality for Mermaid diagrams
 
+## [0.4.4] - 2026-03-02
+
+### Hybrid Architecture Pattern
+- New pattern for complex architectures (15+ elements): simple Mermaid overview (5-8 nodes) + CSS Grid cards for details
+- Updated "Architecture / System Diagrams" section in SKILL.md with three-tier approach based on complexity
+- Reduced max Mermaid node count from 15-20 to 10-12 in `libraries.md`
+- Updated Mermaid scaling guidance to recommend hybrid pattern over scaling tricks for complex diagrams
+
 ## [0.4.3] - 2026-03-01
 
 ### Mermaid Zoom and Positioning Fixes
@@ -150,14 +158,6 @@ Based on PR #25 by [@peak-flow](https://github.com/peak-flow), with additional m
 - Removed unnecessary `.mermaid-inner` wrapper — no longer needed with zoom-based approach.
 - Updated JavaScript to use `INITIAL_ZOOM` constant for consistent reset behavior.
 - Updated "Scaling Small Diagrams" section to use `zoom` instead of `transform: scale()` for consistency.
-
-## [0.4.4] - 2026-03-02
-
-### Hybrid Architecture Pattern
-- New pattern for complex architectures (15+ elements): simple Mermaid overview (5-8 nodes) + CSS Grid cards for details
-- Updated "Architecture / System Diagrams" section in SKILL.md with three-tier approach based on complexity
-- Reduced max Mermaid node count from 15-20 to 10-12 in `libraries.md`
-- Updated Mermaid scaling guidance to recommend hybrid pattern over scaling tricks for complex diagrams
 
 ## [0.4.2] - 2026-03-01
 

--- a/plugins/visual-explainer/extension.ts
+++ b/plugins/visual-explainer/extension.ts
@@ -269,8 +269,12 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
 
   const outputDir = join(homedir(), ".agent", "diagrams");
   const outputPath = join(outputDir, filename);
+  try {
+    if (lstatSync(outputDir).isSymbolicLink()) throw new Error(`${outputDir} must not be a symlink`);
+  } catch (e: any) {
+    if (e.code !== "ENOENT") throw e;
+  }
   mkdirSync(outputDir, { recursive: true });
-  if (lstatSync(outputDir).isSymbolicLink()) throw new Error(`${outputDir} must not be a symlink`);
   if (existsSync(outputPath) && lstatSync(outputPath).isSymbolicLink()) {
     throw new Error(`${outputPath} must not be a symlink`);
   }

--- a/plugins/visual-explainer/templates/slide-deck.html
+++ b/plugins/visual-explainer/templates/slide-deck.html
@@ -682,10 +682,10 @@
     <h2 class="slide__heading reveal">Request Flow</h2>
     <div class="mermaid-wrap reveal">
       <div class="zoom-controls">
-        <button onclick="zoomDiagram(this,1.2)" title="Zoom in">+</button>
-        <button onclick="zoomDiagram(this,0.8)" title="Zoom out">&minus;</button>
-        <button onclick="resetZoom(this)" title="Reset">&#8634;</button>
-        <button onclick="openDiagramFullscreen(this)" title="Open full size in new tab">&#x26F6;</button>
+        <button type="button" onclick="zoomDiagram(this,1.2)" title="Zoom in">+</button>
+        <button type="button" onclick="zoomDiagram(this,0.8)" title="Zoom out">&minus;</button>
+        <button type="button" onclick="resetZoom(this)" title="Reset">&#8634;</button>
+        <button type="button" onclick="openDiagramFullscreen(this)" title="Open full size in new tab">&#x26F6;</button>
       </div>
       <pre class="mermaid">
 graph LR


### PR DESCRIPTION
Noticed the changelog had versions 0.4.3 and 0.4.4 in the wrong order — swapped them so it reads newest-first like the rest of the file.

A few other small things:
- `node_modules/` wasn't in `.gitignore`
- zoom control buttons in the slide-deck template were missing `type="button"`, so they default to `submit` which can cause unexpected behavior inside forms
- the symlink check in `extension.ts` was running after `mkdirSync` — moved it before so it actually catches symlinked output directories before anything gets written