### PR TITLE
Add native Pi visual explainer tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Plugin distribution for visual-explainer",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -13,7 +13,7 @@
       "name": "visual-explainer",
       "source": "./plugins/visual-explainer",
       "description": "Generate beautiful HTML pages for diagrams, diff reviews, plan reviews, slides, and data tables",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "author": {
         "name": "nicobailon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "visual-explainer-marketplace",
   "description": "Plugin distribution for visual-explainer",
-  "version": "0.8.1"
+  "version": "0.8.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-13
+
+### Added
+- Added Pi package gallery image metadata using `banner.png`.
+
 ## [0.8.1] - 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ The package manifest advertises the canonical skill, command templates, and Pi t
 "pi": {
   "extensions": ["./plugins/visual-explainer/extension.ts"],
   "skills": ["./plugins/visual-explainer"],
-  "prompts": ["./plugins/visual-explainer/commands"]
+  "prompts": ["./plugins/visual-explainer/commands"],
+  "image": "./banner.png"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visual-explainer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Agent skill that generates beautiful HTML pages for diagrams, diff reviews, plan reviews, slide decks, and data tables",
   "license": "MIT",
   "homepage": "https://github.com/nicobailon/visual-explainer#readme",
@@ -50,6 +50,7 @@
     ],
     "prompts": [
       "./plugins/visual-explainer/commands"
-    ]
+    ],
+    "image": "./banner.png"
   }
 }

--- a/plugins/visual-explainer/.claude-plugin/plugin.json
+++ b/plugins/visual-explainer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "visual-explainer",
   "description": "Generate beautiful HTML pages for diagrams, diff reviews, plan reviews, slides, and data tables",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "nicobailon"
   },

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires a browser to view generated HTML files. Optional surf-cli for AI image generation.
 metadata:
   author: nicobailon
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # Visual Explainer


### PR DESCRIPTION
Closes #69.\n\nThis updates visual-explainer for current Pi package support. It adds one native `visual_explainer` tool with `prepare` and `render` actions, switches the Pi peer/import to `@earendil-works/pi-coding-agent`, adds package gallery image metadata, removes the share command/script path, and bumps release metadata to `0.8.0`.\n\nValidation run:\n- JSON manifest parse\n- package manifest assertions\n- stale reference grep\n- no `any` in `extension.ts`\n- `node --check plugins/visual-explainer/extension.ts`\n- strict temporary `tsc --noEmit`\n- Pi extension loader smoke\n- `bash -n install-pi.sh`\n- `npm pack --dry-run --json` package contents check\n- `claude plugin validate .`\n- `claude plugin validate plugins/visual-explainer`\n- `git diff --check`