### PR TITLE
Keep slide decks visible without JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Kept slide-deck content visible in no-JS previews such as QuickLook by gating entrance-hidden states on JavaScript availability. Reported by @bradleyy in #68.
+
 ## [0.8.2] - 2026-08-13
 
 ### Added

--- a/plugins/visual-explainer/references/slide-patterns.md
+++ b/plugins/visual-explainer/references/slide-patterns.md
@@ -122,16 +122,23 @@ Slide typography is 2–3× larger than scrollable pages. Page-sized text on a v
 
 ## Cinematic Transitions
 
-IntersectionObserver adds `.visible` when a slide enters the viewport. Slides animate in once and stay visible when scrolling back.
+IntersectionObserver adds `.visible` when a slide enters the viewport. Slides animate in once and stay visible when scrolling back. Gate hidden states on a `.js` class so decks stay readable in no-JS previews such as QuickLook.
+
+```html
+<script>document.documentElement.classList.add('js');</script>
+```
 
 ```css
 /* Slide entrance — fade + lift + subtle scale */
 .slide {
-  opacity: 0;
-  transform: translateY(40px) scale(0.98);
   transition:
     opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
     transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.js .slide {
+  opacity: 0;
+  transform: translateY(40px) scale(0.98);
 }
 
 .slide.visible {
@@ -140,7 +147,7 @@ IntersectionObserver adds `.visible` when a slide enters the viewport. Slides an
 }
 
 /* Staggered child reveals — add .reveal to each content element */
-.slide .reveal {
+.js .slide .reveal {
   opacity: 0;
   transform: translateY(20px);
   transition:

--- a/plugins/visual-explainer/templates/slide-deck.html
+++ b/plugins/visual-explainer/templates/slide-deck.html
@@ -24,6 +24,7 @@
   - Event delegation: Mermaid zoom and table scroll don't trigger slide nav
   - prefers-reduced-motion respected
 -->
+<script>document.documentElement.classList.add('js');</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -103,11 +104,14 @@
     justify-content: center;
     padding: clamp(40px, 6vh, 80px) clamp(40px, 8vw, 120px);
     isolation: isolate;
-    opacity: 0;
-    transform: translateY(40px) scale(0.98);
     transition:
       opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
       transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .js .slide {
+    opacity: 0;
+    transform: translateY(40px) scale(0.98);
   }
 
   .slide.visible {
@@ -115,7 +119,7 @@
     transform: none;
   }
 
-  .slide .reveal {
+  .js .slide .reveal {
     opacity: 0;
     transform: translateY(20px);
     transition:


### PR DESCRIPTION
## Summary
- keep slide-deck content visible when JavaScript is disabled
- gate slide and reveal entrance-hidden states on a root `.js` class
- document the pattern and credit @bradleyy for #68

Closes #68.