### PR TITLE
Apply small backlog maintenance fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - Kept slide-deck content visible in no-JS previews such as QuickLook by gating entrance-hidden states on JavaScript availability. Reported by @bradleyy in #68.
+- Added font-weight guidance so copied Google Fonts examples load each rendered weight, including mono labels. Based on PR #60 by @jowcy.
+- Added small maintenance fixes for `node_modules/` ignores, slide-deck button types, output-directory symlink checks, and older changelog ordering. Based on PR #66 by @fix2015.
 
 ## [0.8.2] - 2026-08-13
 
@@ -148,6 +150,14 @@ Based on PR #25 by [@peak-flow](https://github.com/peak-flow), with additional m
 - Updated `SKILL.md` to explicitly mention the click-to-expand feature and expand button so agents include it when generating pages
 - Updated all prompt templates (`diff-review.md`, `plan-review.md`, `project-recap.md`, `generate-visual-plan.md`) to specify the expand button and click-to-expand functionality for Mermaid diagrams
 
+## [0.4.4] - 2026-03-02
+
+### Hybrid Architecture Pattern
+- New pattern for complex architectures (15+ elements): simple Mermaid overview (5-8 nodes) + CSS Grid cards for details
+- Updated "Architecture / System Diagrams" section in SKILL.md with three-tier approach based on complexity
+- Reduced max Mermaid node count from 15-20 to 10-12 in `libraries.md`
+- Updated Mermaid scaling guidance to recommend hybrid pattern over scaling tricks for complex diagrams
+
 ## [0.4.3] - 2026-03-01
 
 ### Mermaid Zoom and Positioning Fixes
@@ -158,14 +168,6 @@ Based on PR #25 by [@peak-flow](https://github.com/peak-flow), with additional m
 - Removed unnecessary `.mermaid-inner` wrapper — no longer needed with zoom-based approach.
 - Updated JavaScript to use `INITIAL_ZOOM` constant for consistent reset behavior.
 - Updated "Scaling Small Diagrams" section to use `zoom` instead of `transform: scale()` for consistency.
-
-## [0.4.4] - 2026-03-02
-
-### Hybrid Architecture Pattern
-- New pattern for complex architectures (15+ elements): simple Mermaid overview (5-8 nodes) + CSS Grid cards for details
-- Updated "Architecture / System Diagrams" section in SKILL.md with three-tier approach based on complexity
-- Reduced max Mermaid node count from 15-20 to 10-12 in `libraries.md`
-- Updated Mermaid scaling guidance to recommend hybrid pattern over scaling tricks for complex diagrams
 
 ## [0.4.2] - 2026-03-01
 

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -65,7 +65,8 @@ Read only the references needed for the current output:
 - Use CSS custom properties for palette: `--bg`, `--surface`, `--border`, `--text`, `--text-dim`, and 3–5 accents.
 - Pick a clear aesthetic direction before writing: blueprint, editorial, paper/ink, terminal, IDE-inspired, or data-dense.
 - Avoid generic defaults: no body font that is only Inter, Roboto, Arial, Helvetica, or system-ui; no violet/fuchsia Tailwind-default accents as the main palette (`#8b5cf6`, `#7c3aed`, `#a78bfa`, `#d946ef`); no cyan+magenta+purple neon dashboard; no gradient-mesh blobs.
-- Good font pair families: DM Sans + Fira Code; Instrument Serif + JetBrains Mono; IBM Plex Sans + IBM Plex Mono; Bricolage Grotesque + Fragment Mono; Plus Jakarta Sans + Azeret Mono.
+- Good font pair families: DM Sans + Fira Code; Instrument Serif + JetBrains Mono; IBM Plex Sans + IBM Plex Mono; Bricolage Grotesque + JetBrains Mono; Plus Jakarta Sans + Azeret Mono.
+- Load every font weight the CSS uses, including mono labels. Do not rely on faux-bold for 500, 600, or 700 weights.
 - Good accent directions: terracotta+sage, teal+slate, rose+cranberry, amber+emerald, deep blue+gold.
 - Prevent overflow: `min-width: 0` on grid/flex children, `overflow-wrap: break-word` for long text, and scroll containers for wide tables/code.
 - Do not set `display: flex` directly on `<li>` when list markers matter.

--- a/plugins/visual-explainer/extension.ts
+++ b/plugins/visual-explainer/extension.ts
@@ -269,8 +269,8 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
 
   const outputDir = join(homedir(), ".agent", "diagrams");
   const outputPath = join(outputDir, filename);
+  if (existsSync(outputDir) && lstatSync(outputDir).isSymbolicLink()) throw new Error(`${outputDir} must not be a symlink`);
   mkdirSync(outputDir, { recursive: true });
-  if (lstatSync(outputDir).isSymbolicLink()) throw new Error(`${outputDir} must not be a symlink`);
   if (existsSync(outputPath) && lstatSync(outputPath).isSymbolicLink()) {
     throw new Error(`${outputPath} must not be a symlink`);
   }

--- a/plugins/visual-explainer/references/css-patterns.md
+++ b/plugins/visual-explainer/references/css-patterns.md
@@ -9,7 +9,7 @@ Always define both light and dark palettes via custom properties. Start with whi
 ```css
 :root {
   --font-body: 'Outfit', system-ui, sans-serif;
-  --font-mono: 'Space Mono', 'SF Mono', Consolas, monospace;
+  --font-mono: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
 
   --bg: #f8f9fa;
   --surface: #ffffff;

--- a/plugins/visual-explainer/references/libraries.md
+++ b/plugins/visual-explainer/references/libraries.md
@@ -567,14 +567,14 @@ Always load with `display=swap` for fast rendering. Pick a distinctive pairing â
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 ```
 
 Define as CSS variables for easy reference:
 ```css
 :root {
-  --font-body: 'Outfit', system-ui, sans-serif;
-  --font-mono: 'Space Mono', 'SF Mono', Consolas, monospace;
+  --font-body: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SF Mono', Consolas, monospace;
 }
 ```
 
@@ -596,7 +596,7 @@ Define as CSS variables for easy reference:
 | Libre Franklin | Inconsolata | Classic, reliable | Data-dense tables |
 | Playfair Display | Roboto Mono | Elegant contrast | Executive summaries |
 
-The first 5 pairings are recommended for most use cases. Vary across consecutive diagrams.
+The first 5 pairings are recommended for most use cases. Vary across consecutive diagrams. Load every weight the CSS renders. Fragment Mono ships only `400`, and Space Mono ships `400` and `700`; use those only when your mono CSS uses those weights.
 
 ### Typography by Content Voice
 

--- a/plugins/visual-explainer/templates/slide-deck.html
+++ b/plugins/visual-explainer/templates/slide-deck.html
@@ -686,10 +686,10 @@
     <h2 class="slide__heading reveal">Request Flow</h2>
     <div class="mermaid-wrap reveal">
       <div class="zoom-controls">
-        <button onclick="zoomDiagram(this,1.2)" title="Zoom in">+</button>
-        <button onclick="zoomDiagram(this,0.8)" title="Zoom out">&minus;</button>
-        <button onclick="resetZoom(this)" title="Reset">&#8634;</button>
-        <button onclick="openDiagramFullscreen(this)" title="Open full size in new tab">&#x26F6;</button>
+        <button type="button" onclick="zoomDiagram(this,1.2)" title="Zoom in">+</button>
+        <button type="button" onclick="zoomDiagram(this,0.8)" title="Zoom out">&minus;</button>
+        <button type="button" onclick="resetZoom(this)" title="Reset">&#8634;</button>
+        <button type="button" onclick="openDiagramFullscreen(this)" title="Open full size in new tab">&#x26F6;</button>
       </div>
       <pre class="mermaid">
 graph LR


### PR DESCRIPTION
## Summary
- load every rendered Google Font weight and avoid faux-bold mono examples
- add  to 
- add explicit slide-deck zoom button types
- move the output-directory symlink check before directory creation
- restore older changelog order

Credits @jowcy for PR #60 and @fix2015 for PR #66.

Supersedes #60 and #66.