### PR TITLE
Add reader navigation to slide decks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Added
 - Added an optional Glimpse viewer for Pi renders through `visual_explainer` with `viewer: "glimpse"` or `viewer: "auto"`. Requested by @bjesuiter in #55 and prototyped in PR #56.
 - Added a standard self-contained favicon to rendered pages and reference templates. Based on PR #62 by @zereraz.
+- Added reader-first slide deck navigation with an expandable side rail, outline/help overlays, deep links, reading percent, and resume state. Based on PR #65 and PR #67 by @zereraz.
 
 ### Fixed
 - Kept slide-deck content visible in no-JS previews such as QuickLook by gating entrance-hidden states on JavaScript availability. Reported by @bradleyy in #68.
+- Hardened Pi render output with missing `html lang`, missing viewport metadata, and display-math escaping for raw `<` / `>` inside `$$...$$`. Based on PR #65 and PR #67 by @zereraz.
 - Added font-weight guidance so copied Google Fonts examples load each rendered weight, including mono labels. Based on PR #60 by @jowcy.
 - Added small maintenance fixes for `node_modules/` ignores, slide-deck button types, output-directory symlink checks, and older changelog ordering. Based on PR #66 by @fix2015.
 

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -18,7 +18,7 @@ Generate self-contained HTML pages that explain systems, code changes, plans, da
 - If a table would have 4+ rows or 3+ columns, render it as HTML and give only a short chat summary.
 - Write files to `~/.agent/diagrams/` or the explicit eval output path. Use descriptive filenames.
 - Open generated pages in the browser when running normally. In Pi package installs, use `visual_explainer` with `prepare` for planning/context and `render` only after the complete HTML document exists. Use `viewer: "glimpse"` only when the user wants a native Glimpse window and `glimpseui` is installed; `viewer: "auto"` may fall back to the browser.
-- The final page must be a complete self-contained HTML document, including embedded CSS, a self-contained favicon, and any needed JS.
+- The final page must be a complete self-contained HTML document, including embedded CSS, a self-contained favicon, and any needed JS. In Pi, `visual_explainer.render` also adds missing `html lang`, missing viewport metadata, and display-math escaping for raw `<` / `>` inside `$$...$$`.
 
 ## Reference routing
 
@@ -79,7 +79,7 @@ Use slides only when explicitly requested or when a command asks for slides. Sli
 
 - Each slide is one viewport (`100dvh`) with no page-level scrolling.
 - Use larger type, fewer objects per slide, varied compositions, and visible navigation.
-- Include slide nav chrome from `slide-deck.html`: prev/next controls, slide count, keyboard navigation, and carousel dots/indicators.
+- Include slide nav chrome from `slide-deck.html`: prev/next controls, slide count with reading percent, keyboard navigation, expandable reader rail, outline/help overlays, `#slide-N` deep links, and resume state.
 - Before writing HTML, inventory the source and map every source item to slides.
 - Do not drop content to fit a fixed slide count. Add slides instead.
 - Use the 10 slide types from `slide-patterns.md`: Title, Section Divider, Content, Split, Diagram, Dashboard, Table, Code, Quote, Full-Bleed.
@@ -100,6 +100,6 @@ Before delivery, verify:
 - page has a self-contained favicon;
 - tables preserve rows/columns and wrap long text;
 - Mermaid diagrams use `diagram-shell` with zoom/pan/expand;
-- slides fit one viewport, include carousel dots, and preserve source coverage;
+- slides fit one viewport, include reader rail plus outline/help navigation, and preserve source coverage;
 - visual hierarchy makes the main idea obvious in the first viewport;
 - styling would still be recognizable if compared against a generic dark/violet template.

--- a/plugins/visual-explainer/extension.ts
+++ b/plugins/visual-explainer/extension.ts
@@ -152,11 +152,29 @@ function assertHtmlDocument(html: string) {
 
 const standardFavicon = '<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 64 64\'%3E%3Crect width=\'64\' height=\'64\' rx=\'14\' fill=\'%230f172a\'/%3E%3Cpath d=\'M18 40V24l14-8 14 8v16l-14 8-14-8Z\' fill=\'none\' stroke=\'%23fbbf24\' stroke-width=\'4\' stroke-linejoin=\'round\'/%3E%3Ccircle cx=\'32\' cy=\'32\' r=\'5\' fill=\'%2338bdf8\'/%3E%3C/svg%3E">';
 
+function escapeDisplayMath(html: string) {
+  return html.replace(/\$\$([\s\S]*?)\$\$/g, (_match, math: string) => `$$${math.replace(/</g, "&lt;").replace(/>/g, "&gt;")}$$`);
+}
+
 function ensureFavicon(html: string) {
   if (/<link\b[^>]*\brel=["'][^"']*(?:icon|shortcut icon)[^"']*["'][^>]*>/i.test(html)) return html;
   if (/<\/title>/i.test(html)) return html.replace(/<\/title>/i, `</title>\n${standardFavicon}`);
   if (/<head[^>]*>/i.test(html)) return html.replace(/<head[^>]*>/i, (head) => `${head}\n${standardFavicon}`);
   return html.replace(/<html[^>]*>/i, (htmlTag) => `${htmlTag}\n<head>\n${standardFavicon}\n</head>`);
+}
+
+function ensureDocumentMetadata(html: string) {
+  let output = html;
+  if (!/<html\b[^>]*\blang\s*=/i.test(output)) output = output.replace(/<html\b/i, '<html lang="en"');
+  if (!/<head[^>]*>/i.test(output)) output = output.replace(/<html[^>]*>/i, (htmlTag) => `${htmlTag}\n<head></head>`);
+  if (!/<meta\b[^>]*\bname\s*=\s*["']viewport["'][^>]*>/i.test(output)) {
+    output = output.replace(/<head[^>]*>/i, (head) => `${head}\n<meta name="viewport" content="width=device-width, initial-scale=1.0">`);
+  }
+  return output;
+}
+
+function prepareRenderedHtml(html: string) {
+  return ensureDocumentMetadata(ensureFavicon(escapeDisplayMath(html)));
 }
 
 function runOpener(command: string, args: string[], openTarget: OpenTarget): Promise<OpenResult> {
@@ -303,7 +321,7 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
   const filename = outputFilename(params.filename);
   const viewer = params.viewer ?? "browser";
   assertHtmlDocument(params.html);
-  const html = ensureFavicon(params.html);
+  const html = prepareRenderedHtml(params.html);
 
   const outputDir = join(homedir(), ".agent", "diagrams");
   const outputPath = join(outputDir, filename);

--- a/plugins/visual-explainer/references/slide-patterns.md
+++ b/plugins/visual-explainer/references/slide-patterns.md
@@ -180,24 +180,30 @@ IntersectionObserver adds `.visible` when a slide enters the viewport. Slides an
 
 ## Navigation Chrome
 
-All navigation is `position: fixed` with high z-index, layered above slides. Styled to be visible on any background.
+All navigation is `position: fixed` with high z-index, layered above slides. It must stay readable on mixed dark/light backgrounds through a subtle backdrop and text shadow.
 
-### Progress Bar
+Use the full implementation from `templates/slide-deck.html`. Keep it inline and self-contained; do not add an external `engine.js` asset.
 
-```css
-.deck-progress {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 3px;
-  background: var(--accent);
-  z-index: 100;
-  transition: width 0.3s ease;
-  pointer-events: none;
-}
-```
+### Required reader controls
 
-### Nav Dots
+- Top progress bar.
+- Expandable right-side reader rail. At rest it is compact dots. On hover or keyboard focus it expands to show slide titles.
+- Slide counter with reading percent, for example `4 / 12 · 33%`.
+- Keyboard hints that mention arrows, `O` for outline, and `?` for help.
+- Outline overlay opened by `O`.
+- Help overlay opened by `?`.
+- `#slide-N` deep links. A URL hash always wins over saved resume state.
+- Resume with `localStorage`, keyed by path, document title, and slide count to reduce stale resumes after a deck is overwritten.
+
+### Progressive enhancement rules
+
+- Hide entrance states behind `.js` so decks remain visible with JavaScript disabled.
+- Instantiate the deck engine from the inline non-module script, not from the Mermaid module callback. The deck must still become readable if Mermaid fails to load.
+- Use DOM creation and `textContent` for dynamic slide titles. Do not build outline rows with untrusted `innerHTML`.
+- Use real `<button type="button">` controls with `aria-label`, `aria-current`, and visible focus states.
+- Do not let slide-level keyboard navigation run while focus is inside Mermaid, tables, code scroll regions, form controls, or contenteditable regions.
+
+### Shape of the right rail
 
 ```css
 .deck-dots {
@@ -207,225 +213,56 @@ All navigation is `position: fixed` with high z-index, layered above slides. Sty
   transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  z-index: 100;
+  width: 36px;
+  max-height: min(70dvh, 560px);
+  overflow-y: auto;
+  backdrop-filter: blur(4px);
+}
+
+.deck-dots:hover,
+.deck-dots:focus-within {
+  width: min(240px, calc(100vw - 32px));
 }
 
 .deck-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--text-dim);
-  opacity: 0.3;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr);
+  gap: 0;
+  width: 20px;
 }
 
-.deck-dot:hover {
-  opacity: 0.6;
+.deck-dots:hover .deck-dot,
+.deck-dots:focus-within .deck-dot {
+  gap: 10px;
+  width: 100%;
 }
 
-.deck-dot.active {
-  opacity: 1;
-  transform: scale(1.5);
-  background: var(--accent);
-}
-```
-
-### Slide Counter
-
-```css
-.deck-counter {
-  position: fixed;
-  bottom: clamp(12px, 2vh, 24px);
-  right: clamp(12px, 2vw, 24px);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--text-dim);
-  z-index: 100;
-  font-variant-numeric: tabular-nums;
-}
-```
-
-### Keyboard Hints
-
-Auto-fade after first interaction or after 4 seconds.
-
-```css
-.deck-hints {
-  position: fixed;
-  bottom: clamp(12px, 2vh, 24px);
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-dim);
-  opacity: 0.6;
-  z-index: 100;
-  transition: opacity 0.5s ease;
-  white-space: nowrap;
-}
-
-.deck-hints.faded {
+.deck-dot-label {
+  max-width: 0;
+  overflow: hidden;
   opacity: 0;
-  pointer-events: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.deck-dots:hover .deck-dot-label,
+.deck-dots:focus-within .deck-dot-label {
+  max-width: 180px;
+  opacity: 0.9;
 }
 ```
 
-### Chrome Visibility on Mixed Backgrounds
+### SlideEngine responsibilities
 
-For decks where some slides are light and some dark (especially full-bleed slides), nav chrome needs to remain visible. Two approaches:
+The inline `SlideEngine` should own only deck reading behavior:
 
-```css
-/* Approach A: subtle backdrop on chrome elements */
-.deck-dots,
-.deck-counter {
-  background: color-mix(in srgb, var(--bg) 70%, transparent 30%);
-  padding: 6px;
-  border-radius: 20px;
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-}
+1. Build the progress bar, reader rail, counter, hint text, and outline/help overlay.
+2. Extract slide titles from `.slide__display`, `.slide__heading`, `blockquote`, or `.slide__kpi-label`.
+3. Navigate with arrows, PageUp/PageDown, Space, Home/End, touch swipes, rail buttons, and outline buttons.
+4. Observe visible slides and update progress, active rail item, counter, hash, and resume key.
+5. Restore from `#slide-N` first, then from localStorage when no hash exists.
 
-/* Approach B: text shadow for legibility on any background */
-.deck-counter,
-.deck-hints {
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-}
-```
-
-## SlideEngine JavaScript
-
-Add once at the end of the page. Handles navigation, chrome updates, and scroll-triggered reveals. Event delegation ensures slide-internal interactions (Mermaid zoom, scrollable code, overflow tables) don't trigger slide navigation.
-
-```javascript
-class SlideEngine {
-  constructor() {
-    this.deck = document.querySelector('.deck');
-    this.slides = [...document.querySelectorAll('.slide')];
-    this.current = 0;
-    this.total = this.slides.length;
-    this.buildChrome();
-    this.bindEvents();
-    this.observe();
-    this.update();
-  }
-
-  buildChrome() {
-    // Progress bar
-    var bar = document.createElement('div');
-    bar.className = 'deck-progress';
-    document.body.appendChild(bar);
-    this.bar = bar;
-
-    // Nav dots
-    var dots = document.createElement('div');
-    dots.className = 'deck-dots';
-    var self = this;
-    this.slides.forEach(function(_, i) {
-      var d = document.createElement('button');
-      d.className = 'deck-dot';
-      d.title = 'Slide ' + (i + 1);
-      d.onclick = function() { self.goTo(i); };
-      dots.appendChild(d);
-    });
-    document.body.appendChild(dots);
-    this.dots = [].slice.call(dots.children);
-
-    // Counter
-    var ctr = document.createElement('div');
-    ctr.className = 'deck-counter';
-    document.body.appendChild(ctr);
-    this.counter = ctr;
-
-    // Keyboard hints
-    var hints = document.createElement('div');
-    hints.className = 'deck-hints';
-    hints.textContent = '\u2190 \u2192 or scroll to navigate';
-    document.body.appendChild(hints);
-    this.hints = hints;
-    this.hintTimer = setTimeout(function() {
-      hints.classList.add('faded');
-    }, 4000);
-  }
-
-  bindEvents() {
-    var self = this;
-    // Keyboard — skip if focus is inside interactive content
-    document.addEventListener('keydown', function(e) {
-      if (e.target.closest('.mermaid-wrap, .table-scroll, .code-scroll, input, textarea, [contenteditable]')) return;
-      if (['ArrowDown', 'ArrowRight', ' ', 'PageDown'].includes(e.key)) {
-        e.preventDefault(); self.next();
-      } else if (['ArrowUp', 'ArrowLeft', 'PageUp'].includes(e.key)) {
-        e.preventDefault(); self.prev();
-      } else if (e.key === 'Home') {
-        e.preventDefault(); self.goTo(0);
-      } else if (e.key === 'End') {
-        e.preventDefault(); self.goTo(self.total - 1);
-      }
-      self.fadeHints();
-    });
-
-    // Touch swipe
-    var touchY;
-    this.deck.addEventListener('touchstart', function(e) {
-      touchY = e.touches[0].clientY;
-    }, { passive: true });
-    this.deck.addEventListener('touchend', function(e) {
-      var dy = touchY - e.changedTouches[0].clientY;
-      if (Math.abs(dy) > 50) { dy > 0 ? self.next() : self.prev(); }
-    });
-  }
-
-  observe() {
-    var self = this;
-    var obs = new IntersectionObserver(function(entries) {
-      entries.forEach(function(entry) {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('visible');
-          self.current = self.slides.indexOf(entry.target);
-          self.update();
-        }
-      });
-    }, { threshold: 0.5 });
-    this.slides.forEach(function(s) { obs.observe(s); });
-  }
-
-  goTo(i) {
-    this.slides[Math.max(0, Math.min(i, this.total - 1))]
-      .scrollIntoView({ behavior: 'smooth' });
-  }
-
-  next() { if (this.current < this.total - 1) this.goTo(this.current + 1); }
-  prev() { if (this.current > 0) this.goTo(this.current - 1); }
-
-  update() {
-    this.bar.style.width = ((this.current + 1) / this.total * 100) + '%';
-    var self = this;
-    this.dots.forEach(function(d, i) { d.classList.toggle('active', i === self.current); });
-    this.counter.textContent = (this.current + 1) + ' / ' + this.total;
-  }
-
-  fadeHints() {
-    clearTimeout(this.hintTimer);
-    this.hints.classList.add('faded');
-  }
-}
-```
-
-**Usage:** Instantiate after the DOM is ready and any libraries (Mermaid, Chart.js) have rendered. Always call `autoFit()` before `new SlideEngine()` so content is sized correctly before intersection observers fire.
-
-```html
-<script>
-  // After Mermaid/Chart.js initialization (if used), or at end of <body>:
-  document.addEventListener('DOMContentLoaded', function() {
-    autoFit();
-    new SlideEngine();
-  });
-</script>
-```
+Do not add quiz widgets, fact ledgers, validation scripts, fork updaters, or a separate engine file as part of the slide navigation layer.
 
 ## Auto-Fit
 

--- a/plugins/visual-explainer/templates/slide-deck.html
+++ b/plugins/visual-explainer/templates/slide-deck.html
@@ -12,7 +12,7 @@
   and rose (data-table) templates so agents absorb variety.
   Key patterns demonstrated:
   - All 10 slide types in a cohesive narrative
-  - SlideEngine JS: keyboard/touch/wheel nav, progress bar, dots, counter, hints
+  - SlideEngine JS: keyboard/touch/wheel nav, expanding reader rail, outline/help, deep links, resume, progress, counter, hints
   - Cinematic transitions: fade + translateY + scale, staggered child reveals
   - Per-slide background variation (gradient direction, accent glow position)
   - Decorative SVG accents (corner marks, quote mark, divider)
@@ -154,19 +154,50 @@
   .deck-dots {
     position: fixed; right: clamp(12px, 2vw, 24px); top: 50%;
     transform: translateY(-50%); display: flex; flex-direction: column;
-    gap: 8px; z-index: 100; padding: 8px;
+    align-items: flex-end; gap: 6px; z-index: 100; padding: 8px;
+    width: 36px; max-height: min(70dvh, 560px); overflow-y: auto;
     background: color-mix(in srgb, var(--bg) 60%, transparent 40%);
     border-radius: 20px;
     backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+    transition: width 0.2s ease, border-radius 0.2s ease;
+  }
+  .deck-dots:hover,
+  .deck-dots:focus-within {
+    align-items: stretch;
+    width: min(240px, calc(100vw - 32px));
+    border-radius: 18px;
   }
 
   .deck-dot {
-    width: 8px; height: 8px; border-radius: 50%;
-    background: var(--text-dim); opacity: 0.3; border: none; padding: 0;
-    cursor: pointer; transition: opacity 0.2s ease, transform 0.2s ease;
+    display: grid; grid-template-columns: 8px minmax(0, 1fr); align-items: center;
+    gap: 0; width: 20px; min-height: 24px; padding: 7px 6px;
+    border: none; border-radius: 999px; background: transparent; color: var(--text-dim);
+    cursor: pointer; font: 500 11px/1.2 var(--font-mono); text-align: left;
+    opacity: 0.72; transition: opacity 0.2s ease, background 0.2s ease, color 0.2s ease, width 0.2s ease, gap 0.2s ease;
   }
-  .deck-dot:hover { opacity: 0.6; }
-  .deck-dot.active { opacity: 1; transform: scale(1.5); background: var(--accent); }
+  .deck-dot::before {
+    content: ''; width: 8px; height: 8px; border-radius: 50%;
+    background: currentColor; opacity: 0.5; transition: transform 0.2s ease, opacity 0.2s ease;
+  }
+  .deck-dot-label {
+    min-width: 0; max-width: 0; overflow: hidden; opacity: 0;
+    white-space: nowrap; text-overflow: ellipsis;
+    transition: max-width 0.2s ease, opacity 0.2s ease;
+  }
+  .deck-dots:hover .deck-dot,
+  .deck-dots:focus-within .deck-dot {
+    gap: 10px; width: 100%;
+  }
+  .deck-dots:hover .deck-dot-label,
+  .deck-dots:focus-within .deck-dot-label {
+    max-width: 180px; opacity: 0.9;
+  }
+  .deck-dot:hover { opacity: 1; }
+  .deck-dot.active,
+  .deck-dot[aria-current="true"] { background: var(--accent-dim); color: var(--accent); opacity: 1; }
+  .deck-dot.active::before,
+  .deck-dot[aria-current="true"]::before { opacity: 1; transform: scale(1.35); }
+  .deck-dot:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
   .deck-counter {
     position: fixed; bottom: clamp(12px, 2vh, 24px); right: clamp(12px, 2vw, 24px);
@@ -183,6 +214,42 @@
     text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   }
   .deck-hints.faded { opacity: 0; pointer-events: none; }
+
+  .deck-overlay {
+    position: fixed; inset: 0; z-index: 200; display: none;
+    align-items: center; justify-content: center; padding: 24px;
+    background: rgba(0, 0, 0, 0.55); backdrop-filter: blur(3px); -webkit-backdrop-filter: blur(3px);
+  }
+  .deck-overlay.open { display: flex; }
+  .deck-panel {
+    width: min(560px, 86vw); max-height: 80dvh; overflow: auto;
+    background: var(--surface); color: var(--text);
+    border: 1px solid var(--border-bright); border-radius: 14px;
+    padding: 18px 14px; font-family: var(--font-mono);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+  }
+  .deck-panel:focus { outline: none; }
+  .deck-panel__header {
+    margin: 2px 8px 12px; font-size: 12px; letter-spacing: 1px;
+    text-transform: uppercase; color: var(--text-dim);
+  }
+  .deck-panel__button {
+    display: flex; gap: 10px; width: 100%; padding: 8px 10px; border: none;
+    border-radius: 8px; background: transparent; color: inherit; cursor: pointer;
+    font: inherit; font-size: 13px; line-height: 1.3; text-align: left;
+  }
+  .deck-panel__button:hover,
+  .deck-panel__button[aria-current="true"] { background: var(--accent-dim); color: var(--accent); }
+  .deck-panel__number { min-width: 22px; opacity: 0.5; }
+  .deck-help-row {
+    display: flex; justify-content: space-between; gap: 24px;
+    padding: 7px 10px; font-size: 13px;
+  }
+  .deck-help-row span { opacity: 0.7; }
+  .deck-help-row kbd {
+    background: var(--surface2); border-radius: 5px; padding: 2px 8px;
+    font: inherit; color: var(--text);
+  }
 
   /* ============ SHARED SLIDE ELEMENTS ============ */
   .slide__display {
@@ -854,7 +921,8 @@ graph LR
 
   mermaid.run().then(function() {
     autoFit();
-    new SlideEngine();
+  }).catch(function(error) {
+    console.error(error);
   });
 </script>
 
@@ -873,48 +941,112 @@ graph LR
     this.slides=[].slice.call(document.querySelectorAll('.slide'));
     this.current=0;
     this.total=this.slides.length;
+    this.storeKey=['visual-explainer:slide-deck',location.pathname,document.title,this.total].join(':');
     this.buildChrome();
     this.bindEvents();
     this.observe();
+    this.restore();
     this.update();
   }
-  SlideEngine.prototype.buildChrome=function(){
-    var bar=document.createElement('div');bar.className='deck-progress';document.body.appendChild(bar);this.bar=bar;
-    var dots=document.createElement('div');dots.className='deck-dots';var self=this;
-    this.slides.forEach(function(_,i){var d=document.createElement('button');d.className='deck-dot';d.title='Slide '+(i+1);d.onclick=function(){self.goTo(i);};dots.appendChild(d);});
-    document.body.appendChild(dots);this.dots=[].slice.call(dots.children);
-    var ctr=document.createElement('div');ctr.className='deck-counter';document.body.appendChild(ctr);this.counter=ctr;
-    var hints=document.createElement('div');hints.className='deck-hints';hints.textContent='\u2190 \u2192 or scroll to navigate';document.body.appendChild(hints);this.hints=hints;
-    this.hintTimer=setTimeout(function(){hints.classList.add('faded');},4000);
+  SlideEngine.prototype.titleOf=function(i){
+    var s=this.slides[i];
+    var el=s.querySelector('.slide__display,.slide__heading,blockquote,.slide__kpi-label');
+    var title=el?el.textContent.trim().replace(/\s+/g,' '):'';
+    if(!title){var n=s.querySelector('.slide__number');title=n?'Section '+n.textContent.trim():'Slide '+(i+1);}
+    return title.length>58?title.slice(0,56)+'\u2026':title;
   };
+  SlideEngine.prototype.buildChrome=function(){
+    var self=this;
+    var bar=document.createElement('div');bar.className='deck-progress';document.body.appendChild(bar);this.bar=bar;
+    var dots=document.createElement('nav');dots.className='deck-dots';dots.setAttribute('aria-label','Slide navigation');
+    this.slides.forEach(function(_,i){
+      var title=self.titleOf(i);
+      var d=document.createElement('button');d.type='button';d.className='deck-dot';d.title=title;d.setAttribute('aria-label','Go to slide '+(i+1)+': '+title);
+      var label=document.createElement('span');label.className='deck-dot-label';label.textContent=title;d.appendChild(label);
+      d.onclick=function(){self.goTo(i);};dots.appendChild(d);
+    });
+    document.body.appendChild(dots);this.dots=[].slice.call(dots.children);
+    var ctr=document.createElement('div');ctr.className='deck-counter';ctr.setAttribute('aria-live','polite');document.body.appendChild(ctr);this.counter=ctr;
+    var hints=document.createElement('div');hints.className='deck-hints';hints.textContent='\u2190 \u2192 \u00b7 O outline \u00b7 ? help';document.body.appendChild(hints);this.hints=hints;
+    this.hintTimer=setTimeout(function(){hints.classList.add('faded');},4500);
+    var overlay=document.createElement('div');overlay.className='deck-overlay';overlay.setAttribute('aria-hidden','true');
+    var panel=document.createElement('div');panel.className='deck-panel';panel.setAttribute('role','dialog');panel.setAttribute('aria-modal','true');panel.setAttribute('aria-label','Slide deck panel');panel.tabIndex=-1;
+    overlay.appendChild(panel);document.body.appendChild(overlay);this.overlay=overlay;this.panel=panel;
+    overlay.addEventListener('click',function(e){if(e.target===overlay)self.closeOverlay();});
+  };
+  SlideEngine.prototype.clearPanel=function(){while(this.panel.firstChild)this.panel.removeChild(this.panel.firstChild);};
+  SlideEngine.prototype.addPanelHeader=function(text){var h=document.createElement('div');h.className='deck-panel__header';h.textContent=text;this.panel.appendChild(h);};
+  SlideEngine.prototype.renderOutline=function(){
+    var self=this;this.clearPanel();this.addPanelHeader('Outline');
+    this.slides.forEach(function(_,i){
+      var b=document.createElement('button');b.type='button';b.className='deck-panel__button';b.setAttribute('data-i',String(i));
+      if(i===self.current)b.setAttribute('aria-current','true');
+      var n=document.createElement('span');n.className='deck-panel__number';n.textContent=String(i+1);
+      var t=document.createElement('span');t.textContent=self.titleOf(i);
+      b.appendChild(n);b.appendChild(t);b.onclick=function(){self.goTo(i);self.closeOverlay();};self.panel.appendChild(b);
+    });
+  };
+  SlideEngine.prototype.renderHelp=function(){
+    var rows=[['\u2192 / \u2193 / Space','next'],['\u2190 / \u2191','previous'],['Home / End','first / last'],['O','outline'],['?','help'],['Esc','close']];
+    this.clearPanel();this.addPanelHeader('Keyboard');
+    rows.forEach(function(row){
+      var item=document.createElement('div');item.className='deck-help-row';
+      var label=document.createElement('span');label.textContent=row[1];
+      var key=document.createElement('kbd');key.textContent=row[0];
+      item.appendChild(label);item.appendChild(key);this.panel.appendChild(item);
+    },this);
+  };
+  SlideEngine.prototype.openOverlay=function(mode){
+    this.lastFocus=document.activeElement;this.overlay.classList.add('open');this.overlay.setAttribute('aria-hidden','false');
+    mode==='help'?this.renderHelp():this.renderOutline();this.panel.focus();this.fadeHints();
+  };
+  SlideEngine.prototype.closeOverlay=function(){
+    this.overlay.classList.remove('open');this.overlay.setAttribute('aria-hidden','true');
+    if(this.lastFocus&&typeof this.lastFocus.focus==='function')this.lastFocus.focus();
+  };
+  SlideEngine.prototype.overlayOpen=function(){return this.overlay.classList.contains('open');};
   SlideEngine.prototype.bindEvents=function(){
     var self=this;
     document.addEventListener('keydown',function(e){
       if(e.target.closest('.mermaid-wrap,.table-scroll,.code-scroll,input,textarea,[contenteditable]'))return;
+      if(e.key==='Escape'&&self.overlayOpen()){e.preventDefault();self.closeOverlay();return;}
+      if(e.key==='o'||e.key==='O'){e.preventDefault();self.overlayOpen()?self.closeOverlay():self.openOverlay('outline');return;}
+      if(e.key==='?'){e.preventDefault();self.overlayOpen()?self.closeOverlay():self.openOverlay('help');return;}
+      if(self.overlayOpen())return;
       if(['ArrowDown','ArrowRight',' ','PageDown'].indexOf(e.key)>-1){e.preventDefault();self.next();}
       else if(['ArrowUp','ArrowLeft','PageUp'].indexOf(e.key)>-1){e.preventDefault();self.prev();}
       else if(e.key==='Home'){e.preventDefault();self.goTo(0);}
       else if(e.key==='End'){e.preventDefault();self.goTo(self.total-1);}
       self.fadeHints();
     });
+    window.addEventListener('hashchange',function(){var i=self.fromHash();if(i!==null&&i!==self.current)self.goTo(i);});
     var tY;
     this.deck.addEventListener('touchstart',function(e){tY=e.touches[0].clientY;},{passive:true});
     this.deck.addEventListener('touchend',function(e){var dy=tY-e.changedTouches[0].clientY;if(Math.abs(dy)>50){dy>0?self.next():self.prev();}});
+  };
+  SlideEngine.prototype.fromHash=function(){var m=/^#(?:slide-)?(\d+)$/.exec(location.hash);if(!m)return null;var i=(+m[1])-1;return i>=0&&i<this.total?i:null;};
+  SlideEngine.prototype.restore=function(){
+    var i=this.fromHash();
+    if(i===null){try{var saved=localStorage.getItem(this.storeKey);if(saved!==null){var j=parseInt(saved,10);if(j>0&&j<this.total)i=j;}}catch(e){}}
+    if(i!==null&&i>0){var self=this;this.current=i;setTimeout(function(){self.slides[i].scrollIntoView({block:'start'});},60);}
   };
   SlideEngine.prototype.observe=function(){
     var self=this;
     var obs=new IntersectionObserver(function(entries){entries.forEach(function(entry){if(entry.isIntersecting){entry.target.classList.add('visible');self.current=self.slides.indexOf(entry.target);self.update();}});},{threshold:0.5});
     this.slides.forEach(function(s){obs.observe(s);});
   };
-  SlideEngine.prototype.goTo=function(i){this.slides[Math.max(0,Math.min(i,this.total-1))].scrollIntoView({behavior:'smooth'});};
+  SlideEngine.prototype.goTo=function(i){i=Math.max(0,Math.min(i,this.total-1));this.slides[i].scrollIntoView({behavior:'smooth'});};
   SlideEngine.prototype.next=function(){if(this.current<this.total-1)this.goTo(this.current+1);};
   SlideEngine.prototype.prev=function(){if(this.current>0)this.goTo(this.current-1);};
   SlideEngine.prototype.update=function(){
-    this.bar.style.width=((this.current+1)/this.total*100)+'%';
-    var c=this.current;this.dots.forEach(function(d,i){d.classList.toggle('active',i===c);});
-    this.counter.textContent=(this.current+1)+' / '+this.total;
+    var c=this.current,pct=Math.round((c+1)/this.total*100);
+    this.bar.style.width=pct+'%';
+    this.dots.forEach(function(d,i){d.classList.toggle('active',i===c);i===c?d.setAttribute('aria-current','true'):d.removeAttribute('aria-current');});
+    this.counter.textContent=(c+1)+' / '+this.total+' \u00b7 '+pct+'%';
+    try{history.replaceState(null,'','#slide-'+(c+1));localStorage.setItem(this.storeKey,String(c));}catch(e){}
   };
   SlideEngine.prototype.fadeHints=function(){clearTimeout(this.hintTimer);this.hints.classList.add('faded');};
+  new SlideEngine();
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- add reader-first slide deck navigation with an expandable side rail
- add outline and help overlays through `O` and `?`
- add `#slide-N` deep links, reading percent, and resume state keyed by path/title/slide count
- harden `visual_explainer.render` with missing `html lang`, missing viewport metadata, and display-math escaping for raw `<` / `>` inside `$$...$$`

This keeps the deck engine inline and self-contained. It does not add `engine.js`, updater scripts, fact ledger scripts, MCQ widgets, theme-color injection, or new public tool parameters.

Based on PR #65 and PR #67 by @zereraz.

Closes #74.
