### PR TITLE
Add Antigravity CLI support docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added Antigravity CLI install guidance using its native Agent Skills paths, replacing the blocked consumer Gemini CLI support path. Reported by @chadbr in #6.
 - Added an optional Glimpse viewer for Pi renders through `visual_explainer` with `viewer: "glimpse"` or `viewer: "auto"`. Requested by @bjesuiter in #55 and prototyped in PR #56.
 - Added a standard self-contained favicon to rendered pages and reference templates. Based on PR #62 by @zereraz.
 - Added reader-first slide deck navigation with an expandable side rail, outline/help overlays, deep links, reading percent, and resume state. Based on PR #65 and PR #67 by @zereraz.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This skill fixes that. Real typography, dark/light themes, interactive Mermaid d
 |---|---|---|
 | Claude Code | Marketplace plugin | Preserved marketplace shape with source at `plugins/visual-explainer/` |
 | Pi | Package metadata plus installer | `package.json` advertises the skill, prompts, and native `visual_explainer` tool with `prepare` and `render` actions; `install-pi.sh` installs copied skill/prompt resources for legacy manual installs |
+| Antigravity CLI | Native Agent Skills path | Copy `plugins/visual-explainer/` to `~/.gemini/antigravity-cli/skills/visual-explainer` for global use or `.agents/skills/visual-explainer` for one workspace |
 | Codex CLI | Native skill path plus optional prompts | Copy to `~/.codex/skills/visual-explainer`; optional prompts go in `~/.codex/prompts/` if your Codex build supports them |
 | OpenCode/opencode | Observed skill/command paths | Copy to `~/.config/opencode/skill/visual-explainer`; optional commands go in `~/.config/opencode/command/` |
 | Cursor | Rules-based guidance | Add the supplied `.mdc` rule; Cursor is not treated as native Agent Skills support |
@@ -82,6 +83,32 @@ The legacy installer still works if you prefer copied skill and prompt files ove
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nicobailon/visual-explainer/main/install-pi.sh | bash
 ```
+
+**Antigravity CLI:**
+
+Antigravity CLI is the supported Google successor path for consumer Gemini CLI workflows. It loads Agent Skills from `.agents/skills/` at the workspace level or `~/.gemini/antigravity-cli/skills/` globally.
+
+Global install:
+```bash
+git clone --depth 1 https://github.com/nicobailon/visual-explainer.git /tmp/visual-explainer
+
+mkdir -p ~/.gemini/antigravity-cli/skills
+cp -R /tmp/visual-explainer/plugins/visual-explainer ~/.gemini/antigravity-cli/skills/visual-explainer
+
+rm -rf /tmp/visual-explainer
+```
+
+Workspace install:
+```bash
+git clone --depth 1 https://github.com/nicobailon/visual-explainer.git /tmp/visual-explainer
+
+mkdir -p .agents/skills
+cp -R /tmp/visual-explainer/plugins/visual-explainer .agents/skills/visual-explainer
+
+rm -rf /tmp/visual-explainer
+```
+
+Launch `agy` in the project and use `/skills` to confirm `visual-explainer` is discovered. Ask Antigravity to use the `visual-explainer` skill for diagrams, visual reviews, slide decks, and complex tables. Antigravity SDK projects can reuse the same `SKILL.md` content as an Agent Skill resource, but this repo does not ship a separate SDK wrapper. The bundled prompt templates remain reference markdown under `plugins/visual-explainer/commands/`; no separate Antigravity plugin adapter is included.
 
 **Codex CLI:**
 ```bash

--- a/configs/antigravity/AGENTS.md
+++ b/configs/antigravity/AGENTS.md
@@ -1,0 +1,23 @@
+Use the canonical `visual-explainer` skill from `plugins/visual-explainer/`.
+
+For Antigravity CLI, install the skill through native Agent Skills paths. Use `~/.gemini/antigravity-cli/skills/visual-explainer` for global use, or `.agents/skills/visual-explainer` inside one workspace. Antigravity also supports the older `.agent/skills` path, but new docs should use `.agents/skills`.
+
+Install globally:
+
+```bash
+mkdir -p ~/.gemini/antigravity-cli/skills
+cp -R plugins/visual-explainer ~/.gemini/antigravity-cli/skills/visual-explainer
+```
+
+Install in the current workspace:
+
+```bash
+mkdir -p .agents/skills
+cp -R plugins/visual-explainer .agents/skills/visual-explainer
+```
+
+Launch `agy` from the project and run `/skills` to confirm `visual-explainer` is discovered. When the user asks for a diagram, architecture overview, visual review, slide deck, project recap, fact check, or complex comparison table, ask Antigravity to use the `visual-explainer` skill.
+
+Antigravity SDK projects can reuse the same `SKILL.md` content as an Agent Skill resource, but this repo does not ship a separate SDK wrapper. The command markdown files under `plugins/visual-explainer/commands/` remain reference prompts. No separate Antigravity plugin adapter is shipped because that would duplicate the canonical skill directory.
+
+Generated pages should be written to `~/.agent/diagrams/` and opened in a browser when the environment allows it. If browser access is blocked, report the file path.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "claude-code-plugin",
     "claude-marketplace",
     "codex",
+    "antigravity",
+    "antigravity-cli",
     "opencode",
     "openclaw",
     "cursor",


### PR DESCRIPTION
## Summary
- add Antigravity CLI install guidance using native Agent Skills paths
- add `configs/antigravity/AGENTS.md` for harness-specific setup notes
- add Antigravity package keywords
- document SDK reuse as guidance only, without shipping an SDK wrapper or plugin adapter

This uses the CLI-specific global path `~/.gemini/antigravity-cli/skills/visual-explainer` and the workspace path `.agents/skills/visual-explainer`.

Reported by @chadbr in #6.

Closes #6.
