### PR TITLE
docs: add copilot guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added VS Code Copilot and Copilot CLI custom-instruction guidance that points to the canonical skill without claiming native Copilot support. Reported in #8 by @Tal94NICE, with ideas from @davida26 and @jcespinoza.
 - Added Antigravity CLI install guidance using its native Agent Skills paths, replacing the blocked consumer Gemini CLI support path. Reported by @chadbr in #6.
 - Added an optional Glimpse viewer for Pi renders through `visual_explainer` with `viewer: "glimpse"` or `viewer: "auto"`. Requested by @bjesuiter in #55 and prototyped in PR #56.
 - Added a standard self-contained favicon to rendered pages and reference templates. Based on PR #62 by @zereraz.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This skill fixes that. Real typography, dark/light themes, interactive Mermaid d
 | OpenCode/opencode | Observed skill/command paths | Copy to `~/.config/opencode/skill/visual-explainer`; optional commands go in `~/.config/opencode/command/` |
 | Cursor | Rules-based guidance | Add the supplied `.mdc` rule; Cursor is not treated as native Agent Skills support |
 | OpenClaw | Lightweight AGENTS/rules guidance | Use the supplied AGENTS guidance with the canonical skill directory |
+| VS Code Copilot / Copilot CLI | Custom instructions or rules guidance | Add the supplied AGENTS guidance to your supported workspace instruction or rules setup |
 
 **Claude Code (marketplace):**
 ```shell
@@ -147,6 +148,10 @@ Add `configs/cursor/visual-explainer.mdc` to your Cursor rules, or copy its cont
 **OpenClaw:**
 
 Use `configs/openclaw/AGENTS.md` as lightweight project guidance and copy or reference `plugins/visual-explainer/` as the canonical skill source. No native OpenClaw plugin adapter is included.
+
+**VS Code Copilot / Copilot CLI:**
+
+Use `configs/copilot/AGENTS.md` as custom instructions or rules guidance. For VS Code, copy it into a supported workspace custom-instructions file, such as `.github/copilot-instructions.md`. For Copilot CLI, add it through the workspace instruction or rules setup supported by your installed version. Both read the canonical skill from `plugins/visual-explainer/`; this repository does not provide native Agent Skills support, a Copilot package, or a tested Copilot plugin adapter.
 
 ## Commands
 

--- a/configs/copilot/AGENTS.md
+++ b/configs/copilot/AGENTS.md
@@ -1,0 +1,9 @@
+Use the canonical `visual-explainer` skill from `plugins/visual-explainer/`.
+
+VS Code Copilot and Copilot CLI use this as custom instruction or rules guidance. They do not load a native visual-explainer skill, package, or plugin adapter from this repository.
+
+For a VS Code workspace, copy these instructions into the project custom-instructions file, such as `.github/copilot-instructions.md`. For Copilot CLI, use them in the workspace instruction or rules setup supported by the installed CLI version.
+
+When the user asks for a diagram, architecture overview, diff review, plan review, project recap, slide deck, or complex comparison table, read `plugins/visual-explainer/SKILL.md` and follow its workflow. Use the command markdown in `plugins/visual-explainer/commands/` as templates when helpful.
+
+Write generated HTML to `~/.agent/diagrams/` unless the user asks for another path. Open it in a browser only when the environment permits it. If browser access is blocked, report the file path.


### PR DESCRIPTION
Adds docs-only VS Code Copilot and Copilot CLI custom-instruction guidance without claiming native Agent Skills support, a Copilot package, or a tested plugin adapter.\n\nCloses #8.\n\nCredit: reported by @Tal94NICE in #8, with setup ideas from @davida26 and @jcespinoza.\n\nValidation:\n- git diff --check\n- package JSON parse\n- grep for native-support overclaims\n- fresh review: reports/issue-8-copilot-docs-gate-review.md