### PR TITLE
feat: add quick rendering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added VS Code Copilot and Copilot CLI custom-instruction guidance that points to the canonical skill without claiming native Copilot support. Reported in #8 by @Tal94NICE, with ideas from @davida26 and @jcespinoza.
 - Added optional Markdown companion guidance for explicitly requested AI-readable output or source briefs. Companions sit beside HTML output and never become its source. Requested by @mrns in #34.
+- Added opt-in `--quick` rendering for web diagrams, diff reviews, plan reviews, and project recaps. Agents emit a compact validated JSON spec, and the bundled renderer creates complete HTML through the existing Pi tool or a local script fallback. Based on the original RFC idea and PR #12 by @mikeyobrien.
 - Added Antigravity CLI install guidance using its native Agent Skills paths, replacing the blocked consumer Gemini CLI support path. Reported by @chadbr in #6.
 - Added an optional Glimpse viewer for Pi renders through `visual_explainer` with `viewer: "glimpse"` or `viewer: "auto"`. Requested by @bjesuiter in #55 and prototyped in PR #56.
 - Added a standard self-contained favicon to rendered pages and reference templates. Based on PR #62 by @zereraz.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The package manifest advertises the canonical skill, command templates, and Pi t
 }
 ```
 
-The Pi extension registers one native `visual_explainer` tool. Use `action: "prepare"` to plan a visual explanation after generating or reviewing a substantial plan, architecture, diff, or implementation, and `action: "render"` to write complete HTML pages to `~/.agent/diagrams/`. Render can open with `viewer: "browser"` by default, `viewer: "glimpse"` when `glimpseui` is installed, or `viewer: "auto"` to try Glimpse and fall back to the browser. `/generate-web-diagram` remains the bundled prompt template command.
+The Pi extension registers one native `visual_explainer` tool. Use `action: "prepare"` to plan a visual explanation after generating or reviewing a substantial plan, architecture, diff, or implementation, and `action: "render"` to write complete HTML pages to `~/.agent/diagrams/`. The opt-in `action: "render_quick"` validates a compact JSON spec and renders it with the bundled local renderer. Render actions can open with `viewer: "browser"` by default, `viewer: "glimpse"` when `glimpseui` is installed, or `viewer: "auto"` to try Glimpse and fall back to the browser. `/generate-web-diagram` remains the bundled prompt template command.
 
 If you previously used the old curl/manual installer, remove those copied files before using `pi install`; otherwise Pi will report skill and prompt conflicts because the user-level copies shadow the package resources:
 
@@ -167,6 +167,17 @@ Use `configs/copilot/AGENTS.md` as custom instructions or rules guidance. For VS
 
 The agent also kicks in automatically when it's about to dump a complex table in the terminal (4+ rows or 3+ columns) — it renders HTML instead.
 
+## Quick Mode
+
+Add `--quick` to `/generate-web-diagram`, `/diff-review`, `/plan-review`, or `/project-recap` to ask the agent for a compact JSON spec. The bundled renderer validates the spec, escapes its content, and creates a complete self-contained HTML page. Pi uses the existing `visual_explainer` tool with `action: "render_quick"`. Other harnesses can run `plugins/visual-explainer/quick/render.mjs` locally.
+
+Quick mode is opt-in. Commands without `--quick` keep the full custom HTML workflow. The agent also falls back to full mode when the content does not fit the quick schema or when validation or rendering fails.
+
+```text
+/generate-web-diagram --quick authentication request flow
+/diff-review --quick main..HEAD
+```
+
 ## Slide Deck Mode
 
 Any command that produces a scrollable page supports `--slides` to generate a slide deck instead:
@@ -204,6 +215,7 @@ plugins/
     ├── SKILL.md           ← workflow + design principles
     ├── extension.ts       ← Pi native tool
     ├── commands/          ← slash commands
+    ├── quick/             ← JSON schema + deterministic local renderer
     ├── references/        ← agent reads before generating
     │   ├── css-patterns.md   (layouts, animations, theming)
     │   ├── libraries.md      (Mermaid, Chart.js, fonts)

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -21,6 +21,14 @@ Generate self-contained HTML pages that explain systems, code changes, plans, da
 - Open generated pages in the browser when running normally. In Pi package installs, use `visual_explainer` with `prepare` for planning/context and `render` only after the complete HTML document exists. Use `viewer: "glimpse"` only when the user wants a native Glimpse window and `glimpseui` is installed; `viewer: "auto"` may fall back to the browser.
 - The final page must be a complete self-contained HTML document, including embedded CSS, a self-contained favicon, and any needed JS. In Pi, `visual_explainer.render` also adds missing `html lang`, missing viewport metadata, and display-math escaping for raw `<` / `>` inside `$$...$$`.
 
+## Quick mode
+
+Quick mode is opt-in. Use it only when `--quick` appears on `/generate-web-diagram`, `/diff-review`, `/plan-review`, or `/project-recap`. Default and all other prompt behavior remains full HTML generation.
+
+For quick mode, read `./quick/README.md` and `./quick/schema.json`. Gather and verify the same source facts as full mode, but emit the compact JSON spec. In Pi, call the existing `visual_explainer` tool with `action: "render_quick"`, `filename`, `spec`, and optional `open` or `viewer`. In other harnesses, save the JSON and call the local `./quick/render.mjs` script. The renderer validates the spec and creates the complete HTML document.
+
+Quick mode is not suitable for custom visual composition, slides, Mermaid-rich topology, or content that the schema cannot express. If it is not a fit, schema validation fails, or rendering errors, fall back to the normal full HTML workflow and render action. Do not use quick mode for slides, fact-check, visual plans, PPTX, MCP, themes, or updates.
+
 ## Reference routing
 
 Read only the references needed for the current output:

--- a/plugins/visual-explainer/commands/diff-review.md
+++ b/plugins/visual-explainer/commands/diff-review.md
@@ -5,6 +5,10 @@ description: Generate a visual diff review for code changes
 
 Load the visual-explainer skill and generate a self-contained HTML diff review.
 
+## Quick mode
+
+Only use quick mode when `$@` contains the literal `--quick` flag. Remove the flag before scope detection. Complete the same evidence gathering and verification below, then read `./quick/README.md` and `./quick/schema.json` and express the review as a compact spec. In Pi, call `visual_explainer` with `action: "render_quick"`. In other harnesses, run the local `./quick/render.mjs` fallback. If the review does not fit the schema, validation fails, or rendering errors, generate complete HTML and use the normal render flow. Without `--quick`, preserve full HTML behavior.
+
 ## Scope detection
 
 Interpret `$@` as a branch, commit, range, PR, or `HEAD`. If no argument is given, compare the working tree against `main`/`master`.

--- a/plugins/visual-explainer/commands/generate-web-diagram.md
+++ b/plugins/visual-explainer/commands/generate-web-diagram.md
@@ -5,6 +5,8 @@ description: Generate a standalone HTML diagram and open it in the browser
 
 Load the visual-explainer skill and generate an HTML visual explainer for: $@
 
+If `$@` contains the literal `--quick` flag, remove that flag from the topic, read `./quick/README.md` and `./quick/schema.json`, and emit a compact JSON spec instead of HTML. In Pi, call `visual_explainer` with `action: "render_quick"`, a descriptive filename, and the spec. In other harnesses, save the spec and run `node ./quick/render.mjs <spec.json> <output.html>` from the installed skill directory. If the topic does not fit the schema, validation fails, or rendering errors, continue with the full HTML workflow below. Without `--quick`, do not use quick mode.
+
 Use the skill’s reference routing and final checklist. Pick a representation that fits the topic: Mermaid for connected flows/topologies; CSS cards for text-heavy explanations; tables for matrices; timelines for linear history.
 
 Write to `~/.agent/diagrams/` with a descriptive filename and open the result in the browser. In Pi package installs, this is an explicit visual request: use `visual_explainer.prepare` when planning/context scouting helps, then `visual_explainer.render` with the complete HTML.

--- a/plugins/visual-explainer/commands/plan-review.md
+++ b/plugins/visual-explainer/commands/plan-review.md
@@ -5,6 +5,10 @@ description: Compare an implementation plan against the current codebase
 
 Load the visual-explainer skill and generate a self-contained HTML plan review.
 
+## Quick mode
+
+Only use quick mode when `$@` contains the literal `--quick` flag. Remove the flag before resolving the plan input. Complete the same code research and verification below, then read `./quick/README.md` and `./quick/schema.json` and express the review as a compact spec. In Pi, call `visual_explainer` with `action: "render_quick"`. In other harnesses, run the local `./quick/render.mjs` fallback. If the review does not fit the schema, validation fails, or rendering errors, generate complete HTML and use the normal render flow. Without `--quick`, preserve full HTML behavior.
+
 ## Inputs
 
 Use `$@` as the plan path or plan text. If no path is given, ask for the plan.

--- a/plugins/visual-explainer/commands/project-recap.md
+++ b/plugins/visual-explainer/commands/project-recap.md
@@ -5,6 +5,10 @@ description: Generate a visual project recap for context switching
 
 Load the visual-explainer skill and generate a self-contained HTML project recap.
 
+## Quick mode
+
+Only use quick mode when `$@` contains the literal `--quick` flag. Remove the flag before interpreting any recap arguments. Complete the same project research and verification below, then read `./quick/README.md` and `./quick/schema.json` and express the recap as a compact spec. In Pi, call `visual_explainer` with `action: "render_quick"`. In other harnesses, run the local `./quick/render.mjs` fallback. If the recap does not fit the schema, validation fails, or rendering errors, generate complete HTML and use the normal render flow. Without `--quick`, preserve full HTML behavior.
+
 ## Data gathering before HTML
 
 Read project identity files (`README`, changelog, package/build files), top-level tree, current git status, recent commits, unmerged/stale branches, TODO/FIXME in recent files, progress/todo memory if present, and key entry points/source files. Focus on what a returning developer needs to rebuild the mental model.

--- a/plugins/visual-explainer/extension.ts
+++ b/plugins/visual-explainer/extension.ts
@@ -3,9 +3,10 @@ import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { renderQuickSpec } from "./quick/render.mjs";
 
 type VisualExplainerParams = {
-  action: "prepare" | "render";
+  action: "prepare" | "render" | "render_quick";
   topic?: string;
   goal?: string;
   files?: string[];
@@ -13,6 +14,7 @@ type VisualExplainerParams = {
   preferSubagent?: boolean;
   filename?: string;
   html?: string;
+  spec?: unknown;
   open?: boolean;
   viewer?: Viewer;
 };
@@ -50,7 +52,7 @@ type PrepareDetails = {
 };
 
 type RenderDetails = OpenResult & {
-  action: "render";
+  action: "render" | "render_quick";
   path: string;
   viewer: Viewer;
 };
@@ -62,8 +64,8 @@ const visualExplainerParameters = {
   properties: {
     action: {
       type: "string",
-      enum: ["prepare", "render"],
-      description: "Choose prepare to plan a visual explanation, or render to write complete HTML to ~/.agent/diagrams/.",
+      enum: ["prepare", "render", "render_quick"],
+      description: "Choose prepare to plan, render to write complete HTML, or render_quick to validate a compact spec and render it locally.",
     },
     topic: {
       type: "string",
@@ -94,14 +96,19 @@ const visualExplainerParameters = {
       type: "string",
       description: "For action=render: complete self-contained HTML document to write.",
     },
+    spec: {
+      type: "object",
+      description: "For action=render_quick: compact JSON spec that follows quick/schema.json.",
+      additionalProperties: true,
+    },
     open: {
       type: "boolean",
-      description: "For action=render: open the written HTML file in the selected viewer. Defaults to true.",
+      description: "For action=render or render_quick: open the written HTML file in the selected viewer. Defaults to true.",
     },
     viewer: {
       type: "string",
       enum: ["browser", "glimpse", "auto"],
-      description: "For action=render: choose browser, glimpse, or auto. Auto tries glimpseui first, then falls back to the browser. Defaults to browser.",
+      description: "For action=render or render_quick: choose browser, glimpse, or auto. Auto tries glimpseui first, then falls back to the browser. Defaults to browser.",
     },
   },
   required: ["action"],
@@ -308,21 +315,19 @@ function prepareVisualExplanation(pi: ExtensionAPI, params: VisualExplainerParam
   };
 }
 
-async function renderVisualExplanation(params: VisualExplainerParams, signal?: AbortSignal): Promise<AgentToolResult<VisualExplainerDetails>> {
-  if (typeof params.filename !== "string") throw new Error("filename must be a string for action=render");
-  if (typeof params.html !== "string") throw new Error("html must be a string for action=render");
-  if (params.open !== undefined && typeof params.open !== "boolean") throw new Error("open must be a boolean when provided");
-  if (params.viewer !== undefined && params.viewer !== "browser" && params.viewer !== "glimpse" && params.viewer !== "auto") {
-    throw new Error("viewer must be browser, glimpse, or auto when provided");
-  }
-
+async function writeRenderedHtml(
+  action: "render" | "render_quick",
+  filenameInput: string,
+  htmlInput: string,
+  open: boolean | undefined,
+  viewer: Viewer,
+  signal?: AbortSignal,
+): Promise<AgentToolResult<VisualExplainerDetails>> {
   signal?.throwIfAborted();
 
-  const filename = outputFilename(params.filename);
-  const viewer = params.viewer ?? "browser";
-  assertHtmlDocument(params.html);
-  const html = prepareRenderedHtml(params.html);
-
+  const filename = outputFilename(filenameInput);
+  assertHtmlDocument(htmlInput);
+  const html = prepareRenderedHtml(htmlInput);
   const outputDir = join(homedir(), ".agent", "diagrams");
   const outputPath = join(outputDir, filename);
   if (existsSync(outputDir) && lstatSync(outputDir).isSymbolicLink()) throw new Error(`${outputDir} must not be a symlink`);
@@ -336,7 +341,7 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
 
   signal?.throwIfAborted();
 
-  const openResult = params.open === false
+  const openResult = open === false
     ? { openAttempted: false, openStatus: "disabled" as const }
     : await openRenderedPage(outputPath, viewer);
 
@@ -354,30 +359,54 @@ async function renderVisualExplanation(params: VisualExplainerParams, signal?: A
 
   return {
     content: [{ type: "text" as const, text: message }],
-    details: { action: "render", path: outputPath, viewer, ...openResult },
+    details: { action, path: outputPath, viewer, ...openResult },
   };
+}
+
+function validateRenderOptions(params: VisualExplainerParams): asserts params is VisualExplainerParams & { filename: string } {
+  if (typeof params.filename !== "string") throw new Error(`filename must be a string for action=${params.action}`);
+  if (params.open !== undefined && typeof params.open !== "boolean") throw new Error("open must be a boolean when provided");
+  if (params.viewer !== undefined && params.viewer !== "browser" && params.viewer !== "glimpse" && params.viewer !== "auto") {
+    throw new Error("viewer must be browser, glimpse, or auto when provided");
+  }
+}
+
+async function renderVisualExplanation(params: VisualExplainerParams, signal?: AbortSignal): Promise<AgentToolResult<VisualExplainerDetails>> {
+  validateRenderOptions(params);
+  if (typeof params.html !== "string") throw new Error("html must be a string for action=render");
+  return await writeRenderedHtml("render", params.filename, params.html, params.open, params.viewer ?? "browser", signal);
+}
+
+async function renderQuickVisualExplanation(params: VisualExplainerParams, signal?: AbortSignal): Promise<AgentToolResult<VisualExplainerDetails>> {
+  validateRenderOptions(params);
+  if (params.spec === undefined) throw new Error("spec is required for action=render_quick");
+  signal?.throwIfAborted();
+  const html = await renderQuickSpec(params.spec);
+  return await writeRenderedHtml("render_quick", params.filename, html, params.open, params.viewer ?? "browser", signal);
 }
 
 export default function (pi: ExtensionAPI) {
   pi.registerTool<typeof visualExplainerParameters, VisualExplainerDetails>({
     name: "visual_explainer",
     label: "Visual Explainer",
-    description: "Use with action=prepare after generating or reviewing a plan, architecture, diff, or substantial implementation when a visual explanation would help; use action=render after the complete HTML is ready to write it to ~/.agent/diagrams/ and optionally open it.",
-    promptSnippet: "Plan or render visual-explainer HTML. Ask before action=prepare unless visuals were explicitly requested; use action=render as the final write/open step with complete HTML.",
+    description: "Plan visual explanations, write complete HTML, or validate and locally render a compact quick spec to ~/.agent/diagrams/.",
+    promptSnippet: "Plan or render visual-explainer HTML. Use render for complete HTML and render_quick only for an explicit supported --quick prompt.",
     promptGuidelines: [
       "After generating or reviewing a plan, architecture, diff, or substantial implementation, consider offering a visual explanation if it would clarify the work for the user.",
       "Because visual explanations can consume many tokens, ask before calling visual_explainer with action=prepare unless the user explicitly requested a diagram, visual review, recap, or visual plan.",
       "If visual_explainer action=prepare recommends subagent scouting and the subagent tool is available, gather context first, then synthesize complete HTML and finish with visual_explainer action=render.",
       "Use visual_explainer action=render only after generating a complete visual-explainer HTML document; pass a basename-style filename because it writes under ~/.agent/diagrams/. Use viewer=glimpse only when the user wants a native Glimpse window and glimpseui is installed; viewer=auto may fall back to the browser.",
+      "Use action=render_quick only when --quick is explicit on generate-web-diagram, diff-review, plan-review, or project-recap. Pass the compact schema spec. If it fails or does not fit, use the full HTML workflow and action=render.",
     ],
     parameters: visualExplainerParameters,
     executionMode: "sequential",
     async execute(_toolCallId: string, params: VisualExplainerParams, signal?: AbortSignal) {
-      if (params.action !== "prepare" && params.action !== "render") {
-        throw new Error("action must be either 'prepare' or 'render'");
+      if (params.action !== "prepare" && params.action !== "render" && params.action !== "render_quick") {
+        throw new Error("action must be 'prepare', 'render', or 'render_quick'");
       }
 
       if (params.action === "prepare") return prepareVisualExplanation(pi, params);
+      if (params.action === "render_quick") return await renderQuickVisualExplanation(params, signal);
       return await renderVisualExplanation(params, signal);
     },
   });

--- a/plugins/visual-explainer/quick/README.md
+++ b/plugins/visual-explainer/quick/README.md
@@ -1,0 +1,56 @@
+# Quick renderer
+
+Quick mode moves repeated HTML and CSS out of the agent response. The agent emits a compact JSON spec. `render.mjs` validates it and creates one complete, self-contained HTML document.
+
+Quick mode is opt-in. Use it only for `/generate-web-diagram --quick`, `/diff-review --quick`, `/plan-review --quick`, or `/project-recap --quick`. Use full mode if the requested design does not fit the schema or if validation or rendering fails.
+
+## Pi
+
+Call the existing `visual_explainer` tool with:
+
+```json
+{
+  "action": "render_quick",
+  "filename": "auth-flow-quick",
+  "spec": {
+    "title": "Authentication flow",
+    "sections": [
+      {
+        "title": "Request path",
+        "flow": {
+          "nodes": [
+            { "id": "browser", "label": "Browser" },
+            { "id": "api", "label": "API", "tone": "positive" }
+          ],
+          "edges": [{ "from": "browser", "to": "api", "label": "token" }]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Other harnesses
+
+Save the spec as JSON and run:
+
+```bash
+node ./quick/render.mjs spec.json ~/.agent/diagrams/auth-flow-quick.html
+```
+
+Use the `quick` directory relative to the installed visual-explainer skill. Open the result with the harness browser command. If the renderer exits with an error, continue with the normal full HTML workflow.
+
+## Schema
+
+`schema.json` is the authoritative JSON Schema. A spec has a `title`, optional `subtitle` and `summary`, and one or more `sections`. Each section can contain:
+
+- `cards`: compact findings or concepts;
+- `table`: columns and string rows;
+- `risks`: severity-tagged risk items;
+- `files`: paths, details, and change status;
+- `steps`: ordered work or timeline items;
+- `flow`: nodes and directed edges;
+- `callouts`: notes, decisions, or warnings;
+- `evidence`: a label, value, and optional source.
+
+All agent text is HTML-escaped. Unknown properties, invalid enum values, bad flow references, and table rows with the wrong column count fail validation.

--- a/plugins/visual-explainer/quick/base.css
+++ b/plugins/visual-explainer/quick/base.css
@@ -1,0 +1,128 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f1e9;
+  --surface: #fffdf7;
+  --surface-2: #ebe7dc;
+  --border: #c8c1b1;
+  --text: #252a2a;
+  --text-dim: #636b68;
+  --accent: #ad4f32;
+  --positive: #35745c;
+  --warning: #a36d14;
+  --danger: #a33c3c;
+  --info: #356c8c;
+  --shadow: 0 16px 40px rgba(48, 43, 33, 0.09);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #151a19;
+    --surface: #202624;
+    --surface-2: #29302d;
+    --border: #424b47;
+    --text: #f1eee6;
+    --text-dim: #b0b8b3;
+    --accent: #e28564;
+    --positive: #76b99a;
+    --warning: #e3ad55;
+    --danger: #e37a75;
+    --info: #72acd0;
+    --shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+  }
+}
+
+* { box-sizing: border-box; }
+html { background: var(--bg); }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--border) 25%, transparent) 1px, transparent 1px) 0 0 / 32px 32px,
+    linear-gradient(color-mix(in srgb, var(--border) 25%, transparent) 1px, transparent 1px) 0 0 / 32px 32px,
+    var(--bg);
+  color: var(--text);
+  font-family: "Avenir Next", "Trebuchet MS", sans-serif;
+  line-height: 1.55;
+}
+
+main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 52px 0 80px; }
+header { max-width: 800px; margin-bottom: 34px; }
+h1, h2, h3, p { overflow-wrap: anywhere; }
+h1 { margin: 0; font-size: clamp(2.25rem, 7vw, 4.8rem); line-height: .98; letter-spacing: -.055em; text-wrap: balance; }
+h2 { margin: 0; font-size: clamp(1.35rem, 3vw, 2rem); letter-spacing: -.025em; text-wrap: balance; }
+h3 { margin: 0; font-size: 1rem; }
+.subtitle { margin: 15px 0 0; color: var(--accent); font: 500 .78rem/1.5 "Iosevka", "Cascadia Code", monospace; letter-spacing: .08em; text-transform: uppercase; }
+.summary { max-width: 72ch; margin: 18px 0 0; color: var(--text-dim); font-size: 1.08rem; }
+
+.sections { display: grid; gap: 18px; }
+.section {
+  min-width: 0;
+  padding: clamp(20px, 4vw, 34px);
+  border: 1px solid var(--border);
+  border-top: 4px solid var(--tone, var(--accent));
+  border-radius: 5px 5px 18px 5px;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  box-shadow: var(--shadow);
+}
+.section[data-tone="positive"] { --tone: var(--positive); }
+.section[data-tone="warning"] { --tone: var(--warning); }
+.section[data-tone="danger"] { --tone: var(--danger); }
+.section[data-tone="info"] { --tone: var(--info); }
+.section[data-tone="neutral"] { --tone: var(--border); }
+.section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.section-kicker { flex: none; color: var(--tone, var(--accent)); font: 500 .7rem/1 "Iosevka", "Cascadia Code", monospace; letter-spacing: .12em; }
+.section-summary, .section-subtitle { color: var(--text-dim); }
+.section-subtitle { margin: 5px 0 0; }
+.section-summary { max-width: 76ch; margin: 0 0 20px; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr)); gap: 12px; }
+.card, .risk, .callout, .evidence-item {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 4px 4px 12px 4px;
+  background: var(--surface-2);
+}
+.card[data-tone="positive"], .callout[data-tone="positive"] { border-left: 4px solid var(--positive); }
+.card[data-tone="warning"], .callout[data-tone="warning"] { border-left: 4px solid var(--warning); }
+.card[data-tone="danger"], .callout[data-tone="danger"] { border-left: 4px solid var(--danger); }
+.card[data-tone="info"], .callout[data-tone="info"] { border-left: 4px solid var(--info); }
+.card p, .risk p, .callout p { margin: 7px 0 0; color: var(--text-dim); }
+.meta { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+.chip, .status { padding: 3px 7px; border: 1px solid var(--border); border-radius: 3px; font: 500 .68rem/1.35 "Iosevka", "Cascadia Code", monospace; }
+
+.table-wrap { max-width: 100%; overflow-x: auto; border: 1px solid var(--border); border-radius: 4px 4px 12px 4px; }
+table { width: 100%; min-width: 520px; border-collapse: collapse; background: var(--surface); }
+caption { padding: 12px 14px; color: var(--text-dim); text-align: left; }
+th, td { padding: 11px 14px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; overflow-wrap: anywhere; }
+th { background: var(--surface-2); font: 600 .73rem/1.4 "Iosevka", "Cascadia Code", monospace; letter-spacing: .04em; }
+tr:last-child td { border-bottom: 0; }
+
+.risks, .files, .steps, .callouts, .evidence { display: grid; gap: 10px; }
+.risk { display: grid; grid-template-columns: auto 1fr; gap: 12px; }
+.severity { align-self: start; min-width: 68px; padding: 4px 7px; border-radius: 3px; color: var(--surface); background: var(--warning); font: 600 .68rem/1.35 "Iosevka", "Cascadia Code", monospace; text-align: center; text-transform: uppercase; }
+.risk[data-severity="high"] .severity, .risk[data-severity="critical"] .severity { background: var(--danger); }
+.risk[data-severity="low"] .severity { background: var(--positive); }
+.file, .step { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border); }
+.file:last-child, .step:last-child { border-bottom: 0; }
+.file code { overflow-wrap: anywhere; white-space: normal; }
+.file p, .step p { margin: 3px 0 0; color: var(--text-dim); }
+.index { display: grid; place-items: center; width: 28px; height: 28px; border: 1px solid var(--tone, var(--accent)); border-radius: 50%; color: var(--tone, var(--accent)); font: 600 .7rem/1 "Iosevka", "Cascadia Code", monospace; }
+
+.flow { display: grid; gap: 12px; }
+.flow-node { position: relative; min-width: 0; padding: 14px 16px; border: 1px solid var(--border); border-left: 5px solid var(--tone, var(--accent)); border-radius: 3px 3px 12px 3px; background: var(--surface-2); }
+.flow-node p { margin: 4px 0 0; color: var(--text-dim); }
+.flow-edges { display: flex; flex-wrap: wrap; gap: 8px; }
+.flow-edge { color: var(--text-dim); font: 500 .72rem/1.4 "Iosevka", "Cascadia Code", monospace; }
+.flow-edge::before { content: "↳ "; color: var(--accent); }
+.callout { border-left: 4px solid var(--tone, var(--accent)); }
+.evidence { grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr)); }
+.evidence-value { margin-top: 5px; font-weight: 700; font-size: 1.15rem; }
+.evidence-source { margin-top: 8px; color: var(--text-dim); font: 400 .68rem/1.4 "Iosevka", "Cascadia Code", monospace; }
+
+@media (max-width: 620px) {
+  main { width: min(100% - 20px, 1120px); padding-top: 30px; }
+  .section-head { align-items: flex-start; flex-direction: column-reverse; gap: 8px; }
+  .risk { grid-template-columns: 1fr; }
+  .severity { justify-self: start; }
+}

--- a/plugins/visual-explainer/quick/render.mjs
+++ b/plugins/visual-explainer/quick/render.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const quickDir = dirname(fileURLToPath(import.meta.url));
+const tones = new Set(["neutral", "accent", "positive", "warning", "danger", "info"]);
+const severities = new Set(["low", "medium", "high", "critical"]);
+const fileStatuses = new Set(["added", "modified", "deleted", "reviewed", "planned"]);
+const stepStatuses = new Set(["done", "current", "next", "blocked"]);
+const topKeys = new Set(["title", "subtitle", "summary", "sections"]);
+const sectionKeys = new Set(["title", "subtitle", "summary", "tone", "cards", "table", "risks", "files", "steps", "flow", "callouts", "evidence"]);
+const standardFavicon = '<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 64 64\'%3E%3Crect width=\'64\' height=\'64\' rx=\'14\' fill=\'%230f172a\'/%3E%3Cpath d=\'M18 40V24l14-8 14 8v16l-14 8-14-8Z\' fill=\'none\' stroke=\'%23fbbf24\' stroke-width=\'4\' stroke-linejoin=\'round\'/%3E%3Ccircle cx=\'32\' cy=\'32\' r=\'5\' fill=\'%2338bdf8\'/%3E%3C/svg%3E">';
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function checkKeys(value, allowed, path, errors) {
+  for (const key of Object.keys(value)) if (!allowed.has(key)) errors.push(`${path}.${key} is not supported`);
+}
+
+function checkString(value, path, errors, required = false) {
+  if (value === undefined && !required) return;
+  if (typeof value !== "string" || (required && !value.trim())) errors.push(`${path} must be ${required ? "a non-empty" : "a"} string`);
+}
+
+function checkStringArray(value, path, errors, min = 0) {
+  if (!Array.isArray(value) || value.length < min || !value.every((item) => typeof item === "string")) {
+    errors.push(`${path} must be an array of strings${min ? ` with at least ${min} item` : ""}`);
+  }
+}
+
+function checkTone(value, path, errors) {
+  if (value !== undefined && (typeof value !== "string" || !tones.has(value))) errors.push(`${path} must be neutral, accent, positive, warning, danger, or info`);
+}
+
+function checkObjectArray(value, path, errors, allowed, required, validate) {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push(`${path} must be a non-empty array`);
+    return;
+  }
+  value.forEach((item, index) => {
+    const itemPath = `${path}[${index}]`;
+    if (!isRecord(item)) {
+      errors.push(`${itemPath} must be an object`);
+      return;
+    }
+    checkKeys(item, allowed, itemPath, errors);
+    required.forEach((key) => checkString(item[key], `${itemPath}.${key}`, errors, true));
+    validate(item, itemPath, errors);
+  });
+}
+
+export function validateQuickSpec(value) {
+  const errors = [];
+  if (!isRecord(value)) return ["spec must be an object"];
+  checkKeys(value, topKeys, "spec", errors);
+  checkString(value.title, "spec.title", errors, true);
+  checkString(value.subtitle, "spec.subtitle", errors);
+  checkString(value.summary, "spec.summary", errors);
+  if (!Array.isArray(value.sections) || value.sections.length === 0) {
+    errors.push("spec.sections must be a non-empty array");
+    return errors;
+  }
+
+  value.sections.forEach((section, index) => {
+    const path = `spec.sections[${index}]`;
+    if (!isRecord(section)) {
+      errors.push(`${path} must be an object`);
+      return;
+    }
+    checkKeys(section, sectionKeys, path, errors);
+    checkString(section.title, `${path}.title`, errors, true);
+    checkString(section.subtitle, `${path}.subtitle`, errors);
+    checkString(section.summary, `${path}.summary`, errors);
+    checkTone(section.tone, `${path}.tone`, errors);
+
+    if (section.cards !== undefined) checkObjectArray(section.cards, `${path}.cards`, errors, new Set(["title", "body", "meta", "tone"]), ["title"], (item, itemPath) => {
+      checkString(item.body, `${itemPath}.body`, errors);
+      if (item.meta !== undefined) checkStringArray(item.meta, `${itemPath}.meta`, errors);
+      checkTone(item.tone, `${itemPath}.tone`, errors);
+    });
+
+    if (section.table !== undefined) {
+      if (!isRecord(section.table)) errors.push(`${path}.table must be an object`);
+      else {
+        checkKeys(section.table, new Set(["caption", "columns", "rows"]), `${path}.table`, errors);
+        checkString(section.table.caption, `${path}.table.caption`, errors);
+        checkStringArray(section.table.columns, `${path}.table.columns`, errors, 1);
+        if (!Array.isArray(section.table.rows)) errors.push(`${path}.table.rows must be an array`);
+        else section.table.rows.forEach((row, rowIndex) => {
+          checkStringArray(row, `${path}.table.rows[${rowIndex}]`, errors);
+          if (Array.isArray(section.table.columns) && Array.isArray(row) && row.length !== section.table.columns.length) errors.push(`${path}.table.rows[${rowIndex}] must match the column count`);
+        });
+      }
+    }
+
+    if (section.risks !== undefined) checkObjectArray(section.risks, `${path}.risks`, errors, new Set(["title", "body", "severity"]), ["title", "body", "severity"], (item, itemPath) => {
+      if (!severities.has(item.severity)) errors.push(`${itemPath}.severity must be low, medium, high, or critical`);
+    });
+    if (section.files !== undefined) checkObjectArray(section.files, `${path}.files`, errors, new Set(["path", "detail", "status"]), ["path"], (item, itemPath) => {
+      checkString(item.detail, `${itemPath}.detail`, errors);
+      if (item.status !== undefined && !fileStatuses.has(item.status)) errors.push(`${itemPath}.status must be added, modified, deleted, reviewed, or planned`);
+    });
+    if (section.steps !== undefined) checkObjectArray(section.steps, `${path}.steps`, errors, new Set(["title", "body", "status"]), ["title"], (item, itemPath) => {
+      checkString(item.body, `${itemPath}.body`, errors);
+      if (item.status !== undefined && !stepStatuses.has(item.status)) errors.push(`${itemPath}.status must be done, current, next, or blocked`);
+    });
+
+    if (section.flow !== undefined) {
+      if (!isRecord(section.flow)) errors.push(`${path}.flow must be an object`);
+      else {
+        checkKeys(section.flow, new Set(["nodes", "edges"]), `${path}.flow`, errors);
+        checkObjectArray(section.flow.nodes, `${path}.flow.nodes`, errors, new Set(["id", "label", "detail", "tone"]), ["id", "label"], (item, itemPath) => {
+          checkString(item.detail, `${itemPath}.detail`, errors);
+          checkTone(item.tone, `${itemPath}.tone`, errors);
+        });
+        if (!Array.isArray(section.flow.edges)) errors.push(`${path}.flow.edges must be an array`);
+        else {
+          const ids = new Set(Array.isArray(section.flow.nodes) ? section.flow.nodes.filter(isRecord).map((node) => node.id) : []);
+          section.flow.edges.forEach((edge, edgeIndex) => {
+            const edgePath = `${path}.flow.edges[${edgeIndex}]`;
+            if (!isRecord(edge)) errors.push(`${edgePath} must be an object`);
+            else {
+              checkKeys(edge, new Set(["from", "to", "label"]), edgePath, errors);
+              checkString(edge.from, `${edgePath}.from`, errors, true);
+              checkString(edge.to, `${edgePath}.to`, errors, true);
+              checkString(edge.label, `${edgePath}.label`, errors);
+              if (typeof edge.from === "string" && !ids.has(edge.from)) errors.push(`${edgePath}.from must reference a flow node`);
+              if (typeof edge.to === "string" && !ids.has(edge.to)) errors.push(`${edgePath}.to must reference a flow node`);
+            }
+          });
+        }
+      }
+    }
+
+    if (section.callouts !== undefined) checkObjectArray(section.callouts, `${path}.callouts`, errors, new Set(["title", "body", "tone"]), ["body"], (item, itemPath) => {
+      checkString(item.title, `${itemPath}.title`, errors);
+      checkTone(item.tone, `${itemPath}.tone`, errors);
+    });
+    if (section.evidence !== undefined) checkObjectArray(section.evidence, `${path}.evidence`, errors, new Set(["label", "value", "source"]), ["label", "value"], (item, itemPath) => {
+      checkString(item.source, `${itemPath}.source`, errors);
+    });
+  });
+
+  return errors;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}
+
+function tone(value) {
+  return typeof value === "string" && tones.has(value) ? value : "accent";
+}
+
+function renderCards(cards) {
+  if (!cards) return "";
+  return `<div class="grid">${cards.map((card) => `<article class="card" data-tone="${tone(card.tone)}"><h3>${escapeHtml(card.title)}</h3>${card.body ? `<p>${escapeHtml(card.body)}</p>` : ""}${card.meta?.length ? `<div class="meta">${card.meta.map((item) => `<span class="chip">${escapeHtml(item)}</span>`).join("")}</div>` : ""}</article>`).join("")}</div>`;
+}
+
+function renderTable(table) {
+  if (!table) return "";
+  return `<div class="table-wrap"><table>${table.caption ? `<caption>${escapeHtml(table.caption)}</caption>` : ""}<thead><tr>${table.columns.map((column) => `<th scope="col">${escapeHtml(column)}</th>`).join("")}</tr></thead><tbody>${table.rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("")}</tbody></table></div>`;
+}
+
+function renderLists(section) {
+  const risks = section.risks ? `<div class="risks">${section.risks.map((risk) => `<article class="risk" data-severity="${risk.severity}"><span class="severity">${risk.severity}</span><div><h3>${escapeHtml(risk.title)}</h3><p>${escapeHtml(risk.body)}</p></div></article>`).join("")}</div>` : "";
+  const files = section.files ? `<div class="files">${section.files.map((file) => `<div class="file"><span class="status">${escapeHtml(file.status ?? "file")}</span><div><code>${escapeHtml(file.path)}</code>${file.detail ? `<p>${escapeHtml(file.detail)}</p>` : ""}</div></div>`).join("")}</div>` : "";
+  const steps = section.steps ? `<div class="steps">${section.steps.map((step, index) => `<div class="step"><span class="index">${index + 1}</span><div><h3>${escapeHtml(step.title)}</h3>${step.body ? `<p>${escapeHtml(step.body)}</p>` : ""}${step.status ? `<span class="status">${escapeHtml(step.status)}</span>` : ""}</div></div>`).join("")}</div>` : "";
+  return `${risks}${files}${steps}`;
+}
+
+function renderFlow(flow) {
+  if (!flow) return "";
+  return `<div class="flow"><div class="grid">${flow.nodes.map((node) => `<article class="flow-node" data-tone="${tone(node.tone)}"><h3>${escapeHtml(node.label)}</h3>${node.detail ? `<p>${escapeHtml(node.detail)}</p>` : ""}</article>`).join("")}</div>${flow.edges.length ? `<div class="flow-edges">${flow.edges.map((edge) => `<span class="flow-edge">${escapeHtml(edge.from)} → ${escapeHtml(edge.to)}${edge.label ? ` · ${escapeHtml(edge.label)}` : ""}</span>`).join("")}</div>` : ""}</div>`;
+}
+
+function renderCalloutsAndEvidence(section) {
+  const callouts = section.callouts ? `<div class="callouts">${section.callouts.map((callout) => `<aside class="callout" data-tone="${tone(callout.tone)}">${callout.title ? `<h3>${escapeHtml(callout.title)}</h3>` : ""}<p>${escapeHtml(callout.body)}</p></aside>`).join("")}</div>` : "";
+  const evidence = section.evidence ? `<div class="evidence">${section.evidence.map((item) => `<article class="evidence-item"><h3>${escapeHtml(item.label)}</h3><div class="evidence-value">${escapeHtml(item.value)}</div>${item.source ? `<div class="evidence-source">${escapeHtml(item.source)}</div>` : ""}</article>`).join("")}</div>` : "";
+  return `${callouts}${evidence}`;
+}
+
+export async function renderQuickSpec(spec) {
+  const errors = validateQuickSpec(spec);
+  if (errors.length) throw new Error(`Quick spec validation failed:\n- ${errors.join("\n- ")}`);
+  const css = await readFile(join(quickDir, "base.css"), "utf8");
+  const sections = spec.sections.map((section, index) => `<section class="section" data-tone="${tone(section.tone)}"><div class="section-head"><div><h2>${escapeHtml(section.title)}</h2>${section.subtitle ? `<p class="section-subtitle">${escapeHtml(section.subtitle)}</p>` : ""}</div><span class="section-kicker">${String(index + 1).padStart(2, "0")}</span></div>${section.summary ? `<p class="section-summary">${escapeHtml(section.summary)}</p>` : ""}${renderCards(section.cards)}${renderTable(section.table)}${renderLists(section)}${renderFlow(section.flow)}${renderCalloutsAndEvidence(section)}</section>`).join("");
+  return `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<title>${escapeHtml(spec.title)}</title>\n${standardFavicon}\n<style>\n${css}\n</style>\n</head>\n<body>\n<main>\n<header><h1>${escapeHtml(spec.title)}</h1>${spec.subtitle ? `<p class="subtitle">${escapeHtml(spec.subtitle)}</p>` : ""}${spec.summary ? `<p class="summary">${escapeHtml(spec.summary)}</p>` : ""}</header>\n<div class="sections">${sections}</div>\n</main>\n</body>\n</html>\n`;
+}
+
+async function main() {
+  const [specPath, outputPath] = process.argv.slice(2);
+  if (!specPath || !outputPath) throw new Error("Usage: node render.mjs <spec.json> <output.html>");
+  const spec = JSON.parse(await readFile(specPath, "utf8"));
+  const html = await renderQuickSpec(spec);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, html, "utf8");
+  process.stdout.write(`${outputPath}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/visual-explainer/quick/schema.json
+++ b/plugins/visual-explainer/quick/schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/nicobailon/visual-explainer/quick/schema.json",
+  "title": "Visual Explainer quick specification",
+  "type": "object",
+  "required": ["title", "sections"],
+  "additionalProperties": false,
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "subtitle": { "type": "string" },
+    "summary": { "type": "string" },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/section" }
+    }
+  },
+  "$defs": {
+    "tone": {
+      "type": "string",
+      "enum": ["neutral", "accent", "positive", "warning", "danger", "info"]
+    },
+    "card": {
+      "type": "object",
+      "required": ["title"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "body": { "type": "string" },
+        "meta": { "type": "array", "items": { "type": "string" } },
+        "tone": { "$ref": "#/$defs/tone" }
+      }
+    },
+    "table": {
+      "type": "object",
+      "required": ["columns", "rows"],
+      "additionalProperties": false,
+      "properties": {
+        "caption": { "type": "string" },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "required": ["title", "body", "severity"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "body": { "type": "string" },
+        "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] }
+      }
+    },
+    "file": {
+      "type": "object",
+      "required": ["path"],
+      "additionalProperties": false,
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "detail": { "type": "string" },
+        "status": { "type": "string", "enum": ["added", "modified", "deleted", "reviewed", "planned"] }
+      }
+    },
+    "step": {
+      "type": "object",
+      "required": ["title"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "body": { "type": "string" },
+        "status": { "type": "string", "enum": ["done", "current", "next", "blocked"] }
+      }
+    },
+    "flowNode": {
+      "type": "object",
+      "required": ["id", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "detail": { "type": "string" },
+        "tone": { "$ref": "#/$defs/tone" }
+      }
+    },
+    "flowEdge": {
+      "type": "object",
+      "required": ["from", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "from": { "type": "string", "minLength": 1 },
+        "to": { "type": "string", "minLength": 1 },
+        "label": { "type": "string" }
+      }
+    },
+    "flow": {
+      "type": "object",
+      "required": ["nodes", "edges"],
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/flowNode" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/flowEdge" }
+        }
+      }
+    },
+    "callout": {
+      "type": "object",
+      "required": ["body"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string" },
+        "body": { "type": "string" },
+        "tone": { "$ref": "#/$defs/tone" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["label", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" },
+        "source": { "type": "string" }
+      }
+    },
+    "section": {
+      "type": "object",
+      "required": ["title"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "subtitle": { "type": "string" },
+        "summary": { "type": "string" },
+        "tone": { "$ref": "#/$defs/tone" },
+        "cards": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/card" } },
+        "table": { "$ref": "#/$defs/table" },
+        "risks": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/risk" } },
+        "files": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/file" } },
+        "steps": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/step" } },
+        "flow": { "$ref": "#/$defs/flow" },
+        "callouts": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/callout" } },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds opt-in --quick rendering for web diagrams, diff reviews, plan reviews, and project recaps. Agents emit a compact validated JSON spec, and the bundled renderer creates complete HTML through the existing Pi tool or the local script fallback.\n\nCloses #13.\n\nSupersedes draft PR #12. Credit: based on the original RFC idea and PR #12 by @mikeyobrien.\n\nValidation:\n- package JSON parse\n- quick schema JSON parse\n- node --check plugins/visual-explainer/extension.ts\n- node --check plugins/visual-explainer/quick/render.mjs\n- sample quick render with escaping\n- invalid flow reference rejection\n- Pi-stub render_quick smoke\n- no any in extension.ts\n- excluded prompt scan\n- npm pack includes quick files\n- git diff --check\n- fresh exact-head review: reports/issue-13-quick-mode-gate-review-52006cb.md