### PR TITLE
feat: add mcp stdio server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules/
+package-lock.json
+.pi/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added a local stdio MCP server that exposes render tools, bundled prompt templates, and read-only skill resources without HTTP, auth, remote storage, or LLM calls. Requested by @luketych in #33.
 - Added VS Code Copilot and Copilot CLI custom-instruction guidance that points to the canonical skill without claiming native Copilot support. Reported in #8 by @Tal94NICE, with ideas from @davida26 and @jcespinoza.
 - Added optional Markdown companion guidance for explicitly requested AI-readable output or source briefs. Companions sit beside HTML output and never become its source. Requested by @mrns in #34.
 - Added opt-in `--quick` rendering for web diagrams, diff reviews, plan reviews, and project recaps. Agents emit a compact validated JSON spec, and the bundled renderer creates complete HTML through the existing Pi tool or a local script fallback. Based on the original RFC idea and PR #12 by @mikeyobrien.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every coding agent defaults to ASCII art when you ask for a diagram. Box-drawing
 
 Tables are worse. Ask the agent to compare 15 requirements against a plan and you get a wall of pipes and dashes that wraps and breaks in the terminal. The data is there but it's painful to read.
 
-This skill fixes that. Real typography, dark/light themes, interactive Mermaid diagrams with zoom and pan. No build step, no dependencies beyond a browser.
+This skill fixes that. Real typography, dark/light themes, interactive Mermaid diagrams with zoom and pan. Normal skill use has no build step and no dependency beyond a browser; the optional MCP server uses the official MCP SDK.
 
 ## Install
 
@@ -32,6 +32,7 @@ This skill fixes that. Real typography, dark/light themes, interactive Mermaid d
 |---|---|---|
 | Claude Code | Marketplace plugin | Preserved marketplace shape with source at `plugins/visual-explainer/` |
 | Pi | Package metadata plus installer | `package.json` advertises the skill, prompts, and native `visual_explainer` tool with `prepare` and `render` actions; `install-pi.sh` installs copied skill/prompt resources for legacy manual installs |
+| MCP hosts | Local stdio MCP server | `visual-explainer-mcp` exposes render tools, prompt templates, and read-only skill resources without starting an HTTP server |
 | Antigravity CLI | Native Agent Skills path | Copy `plugins/visual-explainer/` to `~/.gemini/antigravity-cli/skills/visual-explainer` for global use or `.agents/skills/visual-explainer` for one workspace |
 | Codex CLI | Native skill path plus optional prompts | Copy to `~/.codex/skills/visual-explainer`; optional prompts go in `~/.codex/prompts/` if your Codex build supports them |
 | OpenCode/opencode | Observed skill/command paths | Copy to `~/.config/opencode/skill/visual-explainer`; optional commands go in `~/.config/opencode/command/` |
@@ -84,6 +85,37 @@ The legacy installer still works if you prefer copied skill and prompt files ove
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nicobailon/visual-explainer/main/install-pi.sh | bash
 ```
+
+**MCP:**
+
+Use `visual-explainer-mcp` from a package install, or run `npm install --no-package-lock` before pointing your host at `plugins/visual-explainer/mcp/server.mjs` from a checkout. Some hosts need an absolute path to the binary. The MCP server is local stdio only. It does not call an LLM, start an HTTP listener, handle credentials, or write outside `~/.agent/diagrams/`.
+
+Example package configuration:
+
+```json
+{
+  "mcpServers": {
+    "visual-explainer": {
+      "command": "visual-explainer-mcp"
+    }
+  }
+}
+```
+
+Example checkout configuration:
+
+```json
+{
+  "mcpServers": {
+    "visual-explainer": {
+      "command": "node",
+      "args": ["/absolute/path/to/visual-explainer/plugins/visual-explainer/mcp/server.mjs"]
+    }
+  }
+}
+```
+
+The server exposes three tools: `visual_explainer_prepare`, `visual_explainer_render_html`, and `visual_explainer_render_quick`. Render tools default to `open: false`; set `open: true` only when you want the server to request a browser or Glimpse window. It also exposes the bundled command templates as MCP prompts and the canonical `SKILL.md`, command markdown, quick README, and quick schema as read-only resources.
 
 **Antigravity CLI:**
 
@@ -216,6 +248,7 @@ plugins/
     ├── extension.ts       ← Pi native tool
     ├── commands/          ← slash commands
     ├── quick/             ← JSON schema + deterministic local renderer
+    ├── mcp/               ← local stdio MCP server
     ├── references/        ← agent reads before generating
     │   ├── css-patterns.md   (layouts, animations, theming)
     │   ├── libraries.md      (Mermaid, Chart.js, fonts)
@@ -229,7 +262,7 @@ plugins/
         └── slide-deck.html
 ```
 
-**Output:** `~/.agent/diagrams/filename.html` → opens in browser. When you explicitly request AI-readable output or a source brief, the agent can also write `~/.agent/diagrams/filename.md` as a concise companion. It asks before replacing an existing companion. HTML remains the final visual output; the Markdown companion is not its source. In Pi package installs, agents can offer `visual_explainer` with `action: "prepare"` after generating or reviewing a substantial plan, architecture, diff, or implementation when a visual explanation would help, then call it with `action: "render"` as the final write/open step.
+**Output:** `~/.agent/diagrams/filename.html` → opens in browser. When you explicitly request AI-readable output or a source brief, the agent can also write `~/.agent/diagrams/filename.md` as a concise companion. It asks before replacing an existing companion. HTML remains the final visual output; the Markdown companion is not its source. In Pi package installs, agents can offer `visual_explainer` with `action: "prepare"` after generating or reviewing a substantial plan, architecture, diff, or implementation when a visual explanation would help, then call it with `action: "render"` as the final write/open step. MCP hosts use the separate `visual-explainer-mcp` stdio server and default render tools to `open: false`.
 
 The skill routes to the right approach automatically: Mermaid for flowcharts and diagrams, CSS Grid for architecture overviews, HTML tables for data, Chart.js for dashboards.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "codex",
     "antigravity",
     "antigravity-cli",
+    "mcp",
+    "model-context-protocol",
     "opencode",
     "openclaw",
     "cursor",
@@ -40,6 +42,13 @@
     "CHANGELOG.md",
     "LICENSE"
   ],
+  "bin": {
+    "visual-explainer-mcp": "./plugins/visual-explainer/mcp/server.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/server": "^2.0.0",
+    "zod": "^4.4.3"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"
   },

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -18,7 +18,7 @@ Generate self-contained HTML pages that explain systems, code changes, plans, da
 - If a table would have 4+ rows or 3+ columns, render it as HTML and give only a short chat summary.
 - Write files to `~/.agent/diagrams/` or the explicit eval output path. Use descriptive filenames.
 - Generate a Markdown companion only when the user explicitly asks for AI-readable output or a source brief. Keep HTML as the final visual output; Markdown is a companion, never the source for HTML. Write `<name>.md` beside `<name>.html` when possible, and ask before replacing an existing companion file.
-- Open generated pages in the browser when running normally. In Pi package installs, use `visual_explainer` with `prepare` for planning/context and `render` only after the complete HTML document exists. Use `viewer: "glimpse"` only when the user wants a native Glimpse window and `glimpseui` is installed; `viewer: "auto"` may fall back to the browser.
+- Open generated pages in the browser when running normally. In Pi package installs, use `visual_explainer` with `prepare` for planning/context and `render` only after the complete HTML document exists. MCP hosts use `visual-explainer-mcp`, which defaults render tools to `open: false`. Use `viewer: "glimpse"` only when the user wants a native Glimpse window and `glimpseui` is installed; `viewer: "auto"` may fall back to the browser.
 - The final page must be a complete self-contained HTML document, including embedded CSS, a self-contained favicon, and any needed JS. In Pi, `visual_explainer.render` also adds missing `html lang`, missing viewport metadata, and display-math escaping for raw `<` / `>` inside `$$...$$`.
 
 ## Quick mode
@@ -27,7 +27,7 @@ Quick mode is opt-in. Use it only when `--quick` appears on `/generate-web-diagr
 
 For quick mode, read `./quick/README.md` and `./quick/schema.json`. Gather and verify the same source facts as full mode, but emit the compact JSON spec. In Pi, call the existing `visual_explainer` tool with `action: "render_quick"`, `filename`, `spec`, and optional `open` or `viewer`. In other harnesses, save the JSON and call the local `./quick/render.mjs` script. The renderer validates the spec and creates the complete HTML document.
 
-Quick mode is not suitable for custom visual composition, slides, Mermaid-rich topology, or content that the schema cannot express. If it is not a fit, schema validation fails, or rendering errors, fall back to the normal full HTML workflow and render action. Do not use quick mode for slides, fact-check, visual plans, PPTX, MCP, themes, or updates.
+Quick mode is not suitable for custom visual composition, slides, Mermaid-rich topology, or content that the schema cannot express. If it is not a fit, schema validation fails, or rendering errors, fall back to the normal full HTML workflow and render action. Do not use quick mode for slides, fact-check, visual plans, PPTX, themes, or updates.
 
 ## Reference routing
 

--- a/plugins/visual-explainer/mcp/README.md
+++ b/plugins/visual-explainer/mcp/README.md
@@ -1,0 +1,74 @@
+# Visual Explainer MCP server
+
+This directory contains the local Model Context Protocol server for visual-explainer.
+
+## Scope
+
+The server is stdio-only. It is meant for MCP hosts that launch a local child process.
+It does not start an HTTP listener, handle credentials, call an LLM, or store output outside the local machine.
+
+Rendered files are written only to `~/.agent/diagrams/`. Filenames must be basenames. Paths, traversal, control characters, and symlink targets are rejected.
+
+## Run from a package install
+
+```json
+{
+  "mcpServers": {
+    "visual-explainer": {
+      "command": "visual-explainer-mcp"
+    }
+  }
+}
+```
+
+## Run from a checkout
+
+Install dependencies first:
+
+```bash
+npm install --no-package-lock
+```
+
+Then point the host at the server entry:
+
+```json
+{
+  "mcpServers": {
+    "visual-explainer": {
+      "command": "node",
+      "args": ["/absolute/path/to/visual-explainer/plugins/visual-explainer/mcp/server.mjs"]
+    }
+  }
+}
+```
+
+## Exposed tools
+
+- `visual_explainer_prepare`: returns a recommended visual explanation flow. It does not write files.
+- `visual_explainer_render_html`: validates a complete HTML document and writes it to `~/.agent/diagrams/`.
+- `visual_explainer_render_quick`: validates a quick-mode JSON spec and writes rendered HTML to `~/.agent/diagrams/`.
+
+Render tools default to `open: false`. Set `open: true` only when you want the server to request a browser or Glimpse window.
+
+## Exposed prompts
+
+The server exposes the bundled command templates as MCP prompts:
+
+- `generate-web-diagram`
+- `generate-visual-plan`
+- `generate-slides`
+- `diff-review`
+- `plan-review`
+- `project-recap`
+- `fact-check`
+
+Pass `request` to fill the template's `$@` argument.
+
+## Exposed resources
+
+The server exposes read-only resources for the canonical skill, command templates, and quick-mode contract:
+
+- `visual-explainer://skill/SKILL.md`
+- `visual-explainer://commands/*.md`
+- `visual-explainer://quick/README.md`
+- `visual-explainer://quick/schema.json`

--- a/plugins/visual-explainer/mcp/server.mjs
+++ b/plugins/visual-explainer/mcp/server.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import * as z from "zod/v4";
+import { renderQuickSpec } from "../quick/render.mjs";
+
+const serverPath = fileURLToPath(import.meta.url);
+const mcpDir = dirname(serverPath);
+const skillDir = dirname(mcpDir);
+const rootDir = join(skillDir, "..", "..");
+const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8"));
+
+const viewerSchema = z.enum(["browser", "glimpse", "auto"]);
+const openStatusSchema = z.enum(["disabled", "unsupported", "dispatched", "failed"]);
+const openTargetSchema = z.enum(["browser", "glimpse"]);
+
+const prepareInputSchema = z.object({
+  topic: z.string().min(1).describe("What the visual explanation should cover."),
+  goal: z.string().optional().describe("What the user wants to understand, decide, or communicate."),
+  files: z.array(z.string()).optional().describe("Relevant files or paths the host model should inspect."),
+  audience: z.string().optional().describe("Intended audience, such as developer, PM, team, reviewer, or executive."),
+}).strict();
+
+const prepareOutputSchema = z.object({
+  topic: z.string(),
+  goal: z.string().optional(),
+  audience: z.string().optional(),
+  files: z.array(z.string()),
+  recommendedFlow: z.array(z.string()),
+});
+
+const renderInputSchema = z.object({
+  filename: z.string().min(1).describe("Basename filename. The server appends .html when no .html/.htm suffix is present."),
+  html: z.string().min(1).describe("Complete self-contained HTML document."),
+  open: z.boolean().default(false).describe("Open the written file after rendering. Defaults to false for MCP."),
+  viewer: viewerSchema.default("browser").describe("Viewer to use when open is true."),
+}).strict();
+
+const renderQuickInputSchema = z.object({
+  filename: z.string().min(1).describe("Basename filename. The server appends .html when no .html/.htm suffix is present."),
+  spec: z.unknown().describe("Compact JSON spec that follows visual-explainer quick/schema.json."),
+  open: z.boolean().default(false).describe("Open the written file after rendering. Defaults to false for MCP."),
+  viewer: viewerSchema.default("browser").describe("Viewer to use when open is true."),
+}).strict();
+
+const renderOutputSchema = z.object({
+  path: z.string(),
+  viewer: viewerSchema,
+  openAttempted: z.boolean(),
+  openStatus: openStatusSchema,
+  openTarget: openTargetSchema.optional(),
+  openError: z.string().optional(),
+  fallbackFrom: openTargetSchema.optional(),
+  fallbackError: z.string().optional(),
+});
+
+const promptArgsSchema = z.object({
+  request: z.string().optional().describe("User-supplied prompt arguments. This replaces $@ in the bundled command template."),
+}).strict();
+
+const promptFiles = [
+  "diff-review.md",
+  "fact-check.md",
+  "generate-slides.md",
+  "generate-visual-plan.md",
+  "generate-web-diagram.md",
+  "plan-review.md",
+  "project-recap.md",
+];
+
+const resourceFiles = [
+  { name: "skill", uri: "visual-explainer://skill/SKILL.md", path: "SKILL.md", title: "Visual Explainer Skill", mimeType: "text/markdown" },
+  { name: "quick-readme", uri: "visual-explainer://quick/README.md", path: "quick/README.md", title: "Quick Mode README", mimeType: "text/markdown" },
+  { name: "quick-schema", uri: "visual-explainer://quick/schema.json", path: "quick/schema.json", title: "Quick Mode JSON Schema", mimeType: "application/schema+json" },
+];
+
+function readSkillFile(relativePath) {
+  return readFileSync(join(skillDir, relativePath), "utf8");
+}
+
+function parsePromptFile(relativePath) {
+  const text = readSkillFile(relativePath);
+  const match = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    const name = relativePath.split("/").pop()?.replace(/\.md$/, "") ?? relativePath;
+    return { name, description: `Visual Explainer prompt from ${relativePath}.`, body: text };
+  }
+
+  const frontmatter = match[1];
+  const body = match[2];
+  const name = frontmatter.match(/^name:\s*(.+)$/m)?.[1]?.trim() ?? relativePath.split("/").pop()?.replace(/\.md$/, "") ?? relativePath;
+  const description = frontmatter.match(/^description:\s*(.+)$/m)?.[1]?.trim() ?? `Visual Explainer prompt from ${relativePath}.`;
+  return { name, description, body };
+}
+
+function outputFilename(input) {
+  if (/[\0-\x1f\x7f]/.test(input)) throw new Error("filename must not contain control characters");
+
+  const raw = input.replace(/^@/, "").trim();
+
+  if (!raw) throw new Error("filename is required");
+  if (raw.includes("/") || raw.includes("\\")) throw new Error("filename must be a basename, not a path");
+  if (raw.includes("..")) throw new Error("filename must not contain '..'");
+
+  return /\.html?$/i.test(raw) ? raw : `${raw}.html`;
+}
+
+function assertHtmlDocument(html) {
+  const trimmed = html.trim();
+  if (!trimmed) throw new Error("html is required");
+
+  const start = trimmed.replace(/^\s*<!doctype\s+html\b[^>]*>\s*/i, "").replace(/^(?:<!--[\s\S]*?-->\s*)+/, "");
+  if (!/^<html[\s>]/i.test(start) || !/<\/html>\s*$/i.test(trimmed)) {
+    throw new Error("html must be a complete HTML document starting with <!doctype html> or <html> and ending with </html>");
+  }
+}
+
+const standardFavicon = '<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 64 64\'%3E%3Crect width=\'64\' height=\'64\' rx=\'14\' fill=\'%230f172a\'/%3E%3Cpath d=\'M18 40V24l14-8 14 8v16l-14 8-14-8Z\' fill=\'none\' stroke=\'%23fbbf24\' stroke-width=\'4\' stroke-linejoin=\'round\'/%3E%3Ccircle cx=\'32\' cy=\'32\' r=\'5\' fill=\'%2338bdf8\'/%3E%3C/svg%3E">';
+
+function escapeDisplayMath(html) {
+  return html.replace(/\$\$([\s\S]*?)\$\$/g, (_match, math) => `$$${math.replace(/</g, "&lt;").replace(/>/g, "&gt;")}$$`);
+}
+
+function ensureFavicon(html) {
+  if (/<link\b[^>]*\brel=["'][^"']*(?:icon|shortcut icon)[^"']*["'][^>]*>/i.test(html)) return html;
+  if (/<\/title>/i.test(html)) return html.replace(/<\/title>/i, `</title>\n${standardFavicon}`);
+  if (/<head[^>]*>/i.test(html)) return html.replace(/<head[^>]*>/i, (head) => `${head}\n${standardFavicon}`);
+  return html.replace(/<html[^>]*>/i, (htmlTag) => `${htmlTag}\n<head>\n${standardFavicon}\n</head>`);
+}
+
+function ensureDocumentMetadata(html) {
+  let output = html;
+  if (!/<html\b[^>]*\blang\s*=/i.test(output)) output = output.replace(/<html\b/i, '<html lang="en"');
+  if (!/<head[^>]*>/i.test(output)) output = output.replace(/<html[^>]*>/i, (htmlTag) => `${htmlTag}\n<head></head>`);
+  if (!/<meta\b[^>]*\bname\s*=\s*["']viewport["'][^>]*>/i.test(output)) {
+    output = output.replace(/<head[^>]*>/i, (head) => `${head}\n<meta name="viewport" content="width=device-width, initial-scale=1.0">`);
+  }
+  return output;
+}
+
+function prepareRenderedHtml(html) {
+  return ensureDocumentMetadata(ensureFavicon(escapeDisplayMath(html)));
+}
+
+function runOpener(command, args, openTarget) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { detached: true, stdio: "ignore", windowsHide: true });
+    let settled = false;
+
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    child.once("error", (error) => {
+      settle({
+        openAttempted: true,
+        openStatus: "failed",
+        openTarget,
+        openError: error.message,
+      });
+    });
+
+    child.once("exit", (code, signal) => {
+      if (code !== 0) {
+        settle({
+          openAttempted: true,
+          openStatus: "failed",
+          openTarget,
+          openError: code === null ? `opener exited with signal ${signal ?? "unknown"}` : `opener exited with code ${code}`,
+        });
+      }
+    });
+
+    const timer = setTimeout(() => {
+      settle({ openAttempted: true, openStatus: "dispatched", openTarget });
+    }, 250);
+
+    child.unref();
+  });
+}
+
+async function openInBrowser(path) {
+  if (process.platform === "darwin") return await runOpener("open", [path], "browser");
+  if (process.platform === "linux") return await runOpener("xdg-open", [path], "browser");
+  if (process.platform === "win32") return await runOpener("cmd", ["/c", "start", "", path], "browser");
+  return { openAttempted: false, openStatus: "unsupported", openTarget: "browser" };
+}
+
+async function openInGlimpse(path) {
+  return await runOpener("glimpseui", ["--width", "1200", "--height", "900", "--title", "Visual Explainer", "--open-links", path], "glimpse");
+}
+
+async function openRenderedPage(path, viewer) {
+  if (viewer === "browser") return await openInBrowser(path);
+  if (viewer === "glimpse") return await openInGlimpse(path);
+
+  const glimpseResult = await openInGlimpse(path);
+  if (glimpseResult.openStatus !== "failed") return glimpseResult;
+
+  const browserResult = await openInBrowser(path);
+  return {
+    ...browserResult,
+    fallbackFrom: "glimpse",
+    fallbackError: glimpseResult.openError ?? "glimpseui failed",
+  };
+}
+
+function compact(value) {
+  return Object.fromEntries(Object.entries(value).filter((entry) => entry[1] !== undefined));
+}
+
+function renderToolResult(message, structuredContent) {
+  return {
+    content: [{ type: "text", text: message }],
+    structuredContent: compact(structuredContent),
+  };
+}
+
+function renderToolError(error) {
+  return {
+    content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }],
+    isError: true,
+  };
+}
+
+function prepareVisualExplanation(params) {
+  const topic = params.topic.trim();
+  if (!topic) throw new Error("topic is required");
+
+  const goal = params.goal?.trim();
+  const audience = params.audience?.trim();
+  const files = params.files?.map((file) => file.trim()).filter(Boolean) ?? [];
+  const recommendedFlow = [
+    "Use the visual-explainer prompt or skill resources to choose the page shape.",
+    "Gather and verify the source facts in the host model. The MCP server does not call an LLM.",
+    "For custom output, generate a complete self-contained HTML document and call visual_explainer_render_html.",
+    "For explicit quick mode, build a compact spec that follows visual-explainer://quick/schema.json and call visual_explainer_render_quick.",
+    "Keep output filenames as basenames. The MCP server writes only under ~/.agent/diagrams/.",
+  ];
+
+  const structuredContent = { topic, goal, audience, files, recommendedFlow };
+  const message = [
+    `Prepared visual explanation for: ${topic}`,
+    goal ? `Goal: ${goal}` : undefined,
+    audience ? `Audience: ${audience}` : undefined,
+    files.length ? `Starting files: ${files.join(", ")}` : undefined,
+    "Recommended flow:",
+    ...recommendedFlow.map((step, index) => `${index + 1}. ${step}`),
+  ].filter(Boolean).join("\n");
+
+  return renderToolResult(message, structuredContent);
+}
+
+async function writeRenderedHtml(filenameInput, htmlInput, open, viewer) {
+  const filename = outputFilename(filenameInput);
+  assertHtmlDocument(htmlInput);
+  const html = prepareRenderedHtml(htmlInput);
+  const outputDir = join(homedir(), ".agent", "diagrams");
+  const outputPath = join(outputDir, filename);
+
+  const outputDirStatus = lstatSync(outputDir, { throwIfNoEntry: false });
+  if (outputDirStatus?.isSymbolicLink()) throw new Error(`${outputDir} must not be a symlink`);
+  mkdirSync(outputDir, { recursive: true });
+  const outputStatus = lstatSync(outputPath, { throwIfNoEntry: false });
+  if (outputStatus?.isSymbolicLink()) throw new Error(`${outputPath} must not be a symlink`);
+
+  writeFileSync(outputPath, html, "utf8");
+
+  const openResult = open ? await openRenderedPage(outputPath, viewer) : { openAttempted: false, openStatus: "disabled" };
+  let message = `Wrote ${outputPath}.`;
+  if (openResult.openStatus === "dispatched") {
+    message += ` ${openResult.openTarget === "glimpse" ? "Glimpse" : "Browser"} open requested.`;
+  } else if (openResult.openStatus === "failed") {
+    message += ` ${openResult.openTarget === "glimpse" ? "Glimpse" : "Browser"} open failed: ${openResult.openError ?? "unknown error"}.`;
+  } else if (openResult.openStatus === "unsupported") {
+    message += " Browser opening is unsupported on this platform.";
+  }
+  if (openResult.fallbackFrom === "glimpse") {
+    message += ` Glimpse fallback reason: ${openResult.fallbackError ?? "unknown error"}.`;
+  }
+
+  return { message, output: compact({ path: outputPath, viewer, ...openResult }) };
+}
+
+function registerResources(server) {
+  for (const resource of resourceFiles) {
+    server.registerResource(resource.name, resource.uri, {
+      title: resource.title,
+      description: `Bundled visual-explainer resource: ${resource.path}`,
+      mimeType: resource.mimeType,
+    }, async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: resource.mimeType, text: readSkillFile(resource.path) }],
+    }));
+  }
+
+  for (const file of promptFiles) {
+    const relativePath = `commands/${file}`;
+    const prompt = parsePromptFile(relativePath);
+    server.registerResource(`command-${prompt.name}`, `visual-explainer://commands/${file}`, {
+      title: `/${prompt.name}`,
+      description: prompt.description,
+      mimeType: "text/markdown",
+    }, async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "text/markdown", text: readSkillFile(relativePath) }],
+    }));
+  }
+}
+
+function registerPrompts(server) {
+  for (const file of promptFiles) {
+    const prompt = parsePromptFile(`commands/${file}`);
+    server.registerPrompt(prompt.name, {
+      title: `/${prompt.name}`,
+      description: prompt.description,
+      argsSchema: promptArgsSchema,
+    }, ({ request }) => ({
+      messages: [{
+        role: "user",
+        content: {
+          type: "text",
+          text: prompt.body.replaceAll("$@", request ?? "").trim(),
+        },
+      }],
+    }));
+  }
+}
+
+function registerTools(server) {
+  server.registerTool("visual_explainer_prepare", {
+    title: "Prepare Visual Explainer",
+    description: "Plan a visual explanation. Does not call an LLM or write files.",
+    inputSchema: prepareInputSchema,
+    outputSchema: prepareOutputSchema,
+    annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+  }, async (params) => {
+    try {
+      return prepareVisualExplanation(params);
+    } catch (error) {
+      return renderToolError(error);
+    }
+  });
+
+  server.registerTool("visual_explainer_render_html", {
+    title: "Render Visual Explainer HTML",
+    description: "Validate and write a complete self-contained HTML document to ~/.agent/diagrams/. Does not call an LLM.",
+    inputSchema: renderInputSchema,
+    outputSchema: renderOutputSchema,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  }, async ({ filename, html, open, viewer }) => {
+    try {
+      const result = await writeRenderedHtml(filename, html, open, viewer);
+      return renderToolResult(result.message, result.output);
+    } catch (error) {
+      return renderToolError(error);
+    }
+  });
+
+  server.registerTool("visual_explainer_render_quick", {
+    title: "Render Visual Explainer Quick Spec",
+    description: "Validate a quick-mode JSON spec and render it to ~/.agent/diagrams/. Does not call an LLM.",
+    inputSchema: renderQuickInputSchema,
+    outputSchema: renderOutputSchema,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  }, async ({ filename, spec, open, viewer }) => {
+    try {
+      const html = await renderQuickSpec(spec);
+      const result = await writeRenderedHtml(filename, html, open, viewer);
+      return renderToolResult(result.message, result.output);
+    } catch (error) {
+      return renderToolError(error);
+    }
+  });
+}
+
+export function createServer() {
+  const server = new McpServer({ name: "visual-explainer", version: packageJson.version });
+  registerResources(server);
+  registerPrompts(server);
+  registerTools(server);
+  return server;
+}
+
+function isMainModule() {
+  return Boolean(process.argv[1] && realpathSync(process.argv[1]) === serverPath);
+}
+
+if (isMainModule()) {
+  const handle = serveStdio(createServer);
+  console.error("visual-explainer MCP server running on stdio");
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => {
+      void handle.close().finally(() => process.exit(0));
+    });
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds optional local stdio MCP support for visual-explainer. The server exposes render tools, bundled prompt templates, and read-only skill resources without HTTP, auth, remote storage, or LLM calls.

Closes #33.

## Validation

- `node --check plugins/visual-explainer/mcp/server.mjs`
- `node --check plugins/visual-explainer/quick/render.mjs`
- `node --check plugins/visual-explainer/extension.ts`
- package JSON dependency/bin assertions
- raw stdio MCP smoke through direct `node server.mjs` and a symlinked `visual-explainer-mcp`
- tool, prompt, and resource listing
- prompt get and resource read
- prepare tool smoke
- invalid HTML, traversal filename, control-character filename, and dangling symlink output-target rejections
- positive `render_html` and `render_quick` with default `open:false`
- `npm pack --dry-run`
- `git diff --check`
- fresh exact-head review: `reports/issue-33-mcp-support-gate-review-16cc32c.md`
