### PR TITLE
feat: add best-effort pptx export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added a best-effort static PPTX export utility for simple HTML slide decks. It extracts slide text, bullets, simple tables, code blocks, and diagram placeholders while keeping HTML as the source of truth. Requested by @romkazor in #50.
 - Added a local stdio MCP server that exposes render tools, bundled prompt templates, and read-only skill resources without HTTP, auth, remote storage, or LLM calls. Requested by @luketych in #33.
 - Added VS Code Copilot and Copilot CLI custom-instruction guidance that points to the canonical skill without claiming native Copilot support. Reported in #8 by @Tal94NICE, with ideas from @davida26 and @jcespinoza.
 - Added optional Markdown companion guidance for explicitly requested AI-readable output or source briefs. Companions sit beside HTML output and never become its source. Requested by @mrns in #34.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every coding agent defaults to ASCII art when you ask for a diagram. Box-drawing
 
 Tables are worse. Ask the agent to compare 15 requirements against a plan and you get a wall of pipes and dashes that wraps and breaks in the terminal. The data is there but it's painful to read.
 
-This skill fixes that. Real typography, dark/light themes, interactive Mermaid diagrams with zoom and pan. Normal skill use has no build step and no dependency beyond a browser; the optional MCP server uses the official MCP SDK.
+This skill fixes that. Real typography, dark/light themes, interactive Mermaid diagrams with zoom and pan. Normal skill use has no build step and no dependency beyond a browser; optional MCP and PPTX utilities use small Node dependencies.
 
 ## Install
 
@@ -33,6 +33,7 @@ This skill fixes that. Real typography, dark/light themes, interactive Mermaid d
 | Claude Code | Marketplace plugin | Preserved marketplace shape with source at `plugins/visual-explainer/` |
 | Pi | Package metadata plus installer | `package.json` advertises the skill, prompts, and native `visual_explainer` tool with `prepare` and `render` actions; `install-pi.sh` installs copied skill/prompt resources for legacy manual installs |
 | MCP hosts | Local stdio MCP server | `visual-explainer-mcp` exposes render tools, prompt templates, and read-only skill resources without starting an HTTP server |
+| PPTX export | Best-effort static utility | `visual-explainer-pptx` converts simple HTML slide decks to `.pptx`; HTML remains the source of truth |
 | Antigravity CLI | Native Agent Skills path | Copy `plugins/visual-explainer/` to `~/.gemini/antigravity-cli/skills/visual-explainer` for global use or `.agents/skills/visual-explainer` for one workspace |
 | Codex CLI | Native skill path plus optional prompts | Copy to `~/.codex/skills/visual-explainer`; optional prompts go in `~/.codex/prompts/` if your Codex build supports them |
 | OpenCode/opencode | Observed skill/command paths | Copy to `~/.config/opencode/skill/visual-explainer`; optional commands go in `~/.config/opencode/command/` |
@@ -219,6 +220,14 @@ Any command that produces a scrollable page supports `--slides` to generate a sl
 /project-recap --slides 2w
 ```
 
+For a portable presentation file, add `--pptx` to `/generate-slides` or run the exporter after generating an HTML deck:
+
+```bash
+visual-explainer-pptx ~/.agent/diagrams/my-deck.html ~/.agent/diagrams/my-deck.pptx
+```
+
+PPTX export is best-effort and static. It extracts titles, text, bullets, simple tables, code blocks, and Mermaid source placeholders from `<section class="slide">` elements. It does not preserve animations, reader navigation, responsive layout, custom fonts, live Mermaid/Chart.js/SVG/canvas rendering, or JavaScript behavior. Use the HTML deck for final fidelity.
+
 https://github.com/user-attachments/assets/342d3558-5fcf-4fb2-bc03-f0dd5b9e35dc
 
 ## Themes
@@ -249,6 +258,7 @@ plugins/
     ├── commands/          ← slash commands
     ├── quick/             ← JSON schema + deterministic local renderer
     ├── mcp/               ← local stdio MCP server
+    ├── pptx/              ← best-effort static PPTX exporter
     ├── references/        ← agent reads before generating
     │   ├── css-patterns.md   (layouts, animations, theming)
     │   ├── libraries.md      (Mermaid, Chart.js, fonts)
@@ -269,6 +279,7 @@ The skill routes to the right approach automatically: Mermaid for flowcharts and
 ## Limitations
 
 - Generated HTML is portable and self-contained, but auto-opening depends on the harness, browser access, and sandbox rules.
+- PPTX export is a static best-effort handoff. The HTML deck remains the source of truth for full visual fidelity.
 - All harnesses write visual output to `~/.agent/diagrams/` unless the user asks for a different path.
 - Switching OS theme requires a page refresh for Mermaid SVGs.
 - Results vary by model capability.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "diff-review",
     "plan-review",
     "slides",
+    "pptx",
+    "powerpoint",
     "mermaid"
   ],
   "files": [
@@ -43,10 +45,13 @@
     "LICENSE"
   ],
   "bin": {
-    "visual-explainer-mcp": "./plugins/visual-explainer/mcp/server.mjs"
+    "visual-explainer-mcp": "./plugins/visual-explainer/mcp/server.mjs",
+    "visual-explainer-pptx": "./plugins/visual-explainer/pptx/export.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "^2.0.0",
+    "node-html-parser": "^9.0.1",
+    "pptxgenjs": "^4.0.1",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -86,7 +86,9 @@ Read only the references needed for the current output:
 
 ## Slide deck mode
 
-Use slides only when explicitly requested or when a command asks for slides. Slides are a different medium, not a paginated article:
+Use slides only when explicitly requested or when a command asks for slides. Slides are a different medium, not a paginated article. If the user explicitly asks for PPTX or passes `--pptx` to `/generate-slides`, generate the HTML deck first, then use the best-effort static exporter in `./pptx/export.mjs` or the `visual-explainer-pptx` binary when package or checkout dependencies are available. If they are not available, deliver the HTML deck and explain the missing export dependency path. State that HTML remains the source of truth and PPTX does not preserve animations, reader navigation, responsive layout, custom fonts, live Mermaid/Chart.js/SVG/canvas rendering, or JavaScript behavior.
+
+Slides rules:
 
 - Each slide is one viewport (`100dvh`) with no page-level scrolling.
 - Use larger type, fewer objects per slide, varied compositions, and visible navigation.
@@ -112,7 +114,7 @@ Before delivery, verify:
 - tables preserve rows/columns and wrap long text;
 - Mermaid diagrams use `diagram-shell` with zoom/pan/expand;
 - a runtime picker, if present, swaps palette and font variables and re-renders every diagram;
-- slides fit one viewport, include reader rail plus outline/help navigation, and preserve source coverage;
+- slides fit one viewport, include reader rail plus outline/help navigation, and preserve source coverage; if PPTX was requested, the static `.pptx` was generated after the HTML deck and its fidelity limits were stated;
 - visual hierarchy makes the main idea obvious in the first viewport;
 - styling would still be recognizable if compared against a generic dark/violet template;
 - if requested, the Markdown companion is a concise source brief that matches the delivered HTML without becoming its source of truth.

--- a/plugins/visual-explainer/commands/generate-slides.md
+++ b/plugins/visual-explainer/commands/generate-slides.md
@@ -5,6 +5,8 @@ description: Generate a slide deck as a self-contained HTML page
 
 Load the visual-explainer skill and generate a slide deck for: $@
 
+If `$@` contains the literal `--pptx` flag, remove that flag from the topic. Generate the HTML slide deck first, then run the best-effort static exporter with `visual-explainer-pptx <deck.html> <deck.pptx>` from package installs or `node ./pptx/export.mjs <deck.html> <deck.pptx>` from a checkout after dependencies are installed. If the exporter dependencies are not available, deliver the HTML deck and explain that PPTX export needs the package install or checkout dependencies. Tell the user that the HTML deck remains the source of truth and the PPTX will not preserve animations, reader navigation, responsive layout, custom fonts, live Mermaid/Chart.js/SVG/canvas rendering, or JavaScript behavior.
+
 Before writing HTML, read `./templates/slide-deck.html`, `./references/slide-patterns.md`, and only the shared CSS/library sections needed for the source.
 
 Plan the deck first: inventory the source, map every item to slides, choose a narrative arc, and assign a composition to each slide. Use the 10 slide types and nav chrome from `slide-patterns.md`/`slide-deck.html`, including carousel dots, prev/next, slide count, and keyboard controls. Keep each slide to `100dvh`; split dense content across slides rather than scrolling or dropping content.

--- a/plugins/visual-explainer/pptx/README.md
+++ b/plugins/visual-explainer/pptx/README.md
@@ -1,0 +1,32 @@
+# Best-effort PPTX export
+
+`visual-explainer-pptx` converts a generated visual-explainer HTML slide deck into a static `.pptx` file.
+
+The HTML deck remains the source of truth. This exporter is intentionally best-effort and supports simple decks with `<section class="slide">` elements. It extracts slide titles, short text, bullets, simple tables, code blocks, and Mermaid source placeholders.
+
+It does not preserve:
+
+- animations or transitions;
+- reader rail, outline, help, deep links, or resume state;
+- responsive layout;
+- custom web fonts;
+- live Mermaid rendering, Chart.js, SVG, canvas, or JavaScript behavior.
+
+## Usage
+
+From a package install:
+
+```bash
+visual-explainer-pptx ~/.agent/diagrams/my-deck.html ~/.agent/diagrams/my-deck.pptx
+```
+
+From a checkout, install dependencies first:
+
+```bash
+npm install --no-package-lock
+node plugins/visual-explainer/pptx/export.mjs ~/.agent/diagrams/my-deck.html ~/.agent/diagrams/my-deck.pptx
+```
+
+If you omit the output path, the exporter writes beside the input with a `.pptx` suffix.
+
+Use the HTML output for final fidelity. Use the `.pptx` as a portable static handoff when a presentation file is required.

--- a/plugins/visual-explainer/pptx/export.mjs
+++ b/plugins/visual-explainer/pptx/export.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+import { realpathSync } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "node-html-parser";
+import pptxgen from "pptxgenjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const SLIDE_W = 13.333;
+const SLIDE_H = 7.5;
+const MARGIN_X = 0.65;
+const COLORS = {
+  bg: "0F172A",
+  surface: "172033",
+  text: "F8FAFC",
+  dim: "CBD5E1",
+  accent: "D4A73A",
+  border: "334155",
+};
+const IGNORE_SELECTORS = [
+  "script",
+  "style",
+  "button",
+  "svg",
+  "canvas",
+  "nav",
+  ".deck-progress",
+  ".deck-dots",
+  ".deck-counter",
+  ".deck-hint",
+  ".deck-nav",
+  ".reader-rail",
+  ".reader-panel",
+  ".outline-overlay",
+  ".help-overlay",
+  ".zoom-controls",
+].join(",");
+
+function usage() {
+  return [
+    "Usage: visual-explainer-pptx <input.html> [output.pptx]",
+    "",
+    "Best-effort static export for simple visual-explainer HTML slide decks.",
+    "The HTML deck remains the source of truth. Animations, reader navigation, responsive layout, and Mermaid rendering are not preserved.",
+  ].join("\n");
+}
+
+function textOf(node) {
+  return (node?.textContent ?? "")
+    .replace(/\u00a0/g, " ")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/\s*\n\s*/g, "\n")
+    .trim();
+}
+
+function oneLine(node) {
+  return textOf(node).replace(/\s+/g, " ").trim();
+}
+
+function unique(values) {
+  const seen = new Set();
+  const output = [];
+  for (const value of values) {
+    const key = value.toLowerCase();
+    if (!value || seen.has(key)) continue;
+    seen.add(key);
+    output.push(value);
+  }
+  return output;
+}
+
+function truncate(value, max) {
+  if (value.length <= max) return value;
+  return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function outputPathFor(inputPath, explicitPath) {
+  if (explicitPath) return explicitPath;
+  return extname(inputPath) ? inputPath.replace(/\.[^.]+$/, ".pptx") : `${inputPath}.pptx`;
+}
+
+function cloneCleanSlide(slide) {
+  const root = parse(slide.toString());
+  const copy = root.querySelector(".slide") ?? root;
+  for (const ignored of copy.querySelectorAll(IGNORE_SELECTORS)) {
+    if (ignored.classList?.contains("diagram-source")) continue;
+    ignored.remove();
+  }
+  return copy;
+}
+
+function firstText(slide, selectors) {
+  for (const selector of selectors) {
+    const value = oneLine(slide.querySelector(selector));
+    if (value) return value;
+  }
+  return "";
+}
+
+function extractTables(slide) {
+  const tables = [];
+  for (const table of slide.querySelectorAll("table")) {
+    const rows = [];
+    for (const tr of table.querySelectorAll("tr")) {
+      const cells = tr.querySelectorAll("th,td").map((cell) => truncate(oneLine(cell), 90));
+      if (cells.some(Boolean)) rows.push(cells);
+    }
+    if (rows.length) tables.push(rows);
+    table.remove();
+  }
+  return tables;
+}
+
+function extractCodeBlocks(slide) {
+  const blocks = [];
+  for (const code of slide.querySelectorAll("pre")) {
+    const text = textOf(code);
+    if (text) blocks.push(truncate(text, 850));
+    code.remove();
+  }
+  return blocks;
+}
+
+function extractDiagramPlaceholders(slide) {
+  const diagrams = [];
+  for (const diagram of slide.querySelectorAll(".mermaid, .diagram-source")) {
+    const text = textOf(diagram);
+    diagrams.push(text ? `Diagram source: ${truncate(text.replace(/\s+/g, " "), 220)}` : "Diagram placeholder: render from the HTML deck for full fidelity.");
+    diagram.remove();
+  }
+  return diagrams;
+}
+
+function extractSlide(slide, index) {
+  const clean = cloneCleanSlide(slide);
+  const tables = extractTables(clean);
+  const diagrams = extractDiagramPlaceholders(clean);
+  const codeBlocks = extractCodeBlocks(clean);
+  const headings = clean.querySelectorAll("h1,h2,h3,h4").map(oneLine).filter(Boolean);
+  const title = headings[0] || `Slide ${index + 1}`;
+  const subtitle = firstText(clean, [".slide__subtitle", ".subtitle", ".eyebrow", ".kicker"]);
+  const listItems = clean.querySelectorAll("li").map((item) => truncate(oneLine(item), 160)).filter(Boolean);
+  const paragraphs = clean.querySelectorAll("p").map((paragraph) => truncate(oneLine(paragraph), 220)).filter(Boolean);
+  const cardTexts = clean.querySelectorAll("article, aside, .card, .panel, .metric-card")
+    .map((card) => truncate(oneLine(card), 220))
+    .filter(Boolean);
+
+  const body = unique([
+    ...diagrams,
+    ...listItems,
+    ...cardTexts,
+    ...paragraphs,
+  ].filter((value) => value !== title && value !== subtitle));
+
+  return {
+    title: truncate(title, 140),
+    subtitle: truncate(subtitle, 180),
+    body: body.slice(0, 10),
+    tables: tables.slice(0, 2),
+    codeBlocks: codeBlocks.slice(0, 2),
+  };
+}
+
+function findSlideSections(root) {
+  const sections = root.querySelectorAll("section.slide");
+  if (sections.length) return sections;
+  return root.querySelectorAll(".slide").filter((node) => node.querySelector("h1,h2,h3,h4,p,li,table,pre"));
+}
+
+function addFooter(slide, index, total) {
+  slide.addShape("line", { x: MARGIN_X, y: 6.95, w: SLIDE_W - MARGIN_X * 2, h: 0, line: { color: COLORS.border, pt: 1 } });
+  slide.addText(`Best-effort PPTX export · ${index + 1}/${total}`, {
+    x: MARGIN_X,
+    y: 7.05,
+    w: 7.5,
+    h: 0.25,
+    fontFace: "Aptos",
+    fontSize: 8,
+    color: COLORS.dim,
+    margin: 0,
+  });
+}
+
+function addTitle(slide, data) {
+  slide.addText(data.title, {
+    x: MARGIN_X,
+    y: 0.45,
+    w: SLIDE_W - MARGIN_X * 2,
+    h: 0.72,
+    fontFace: "Aptos Display",
+    fontSize: data.title.length > 72 ? 24 : 30,
+    bold: true,
+    color: COLORS.text,
+    margin: 0,
+    fit: "shrink",
+  });
+  if (data.subtitle) {
+    slide.addText(data.subtitle, {
+      x: MARGIN_X,
+      y: 1.22,
+      w: SLIDE_W - MARGIN_X * 2,
+      h: 0.35,
+      fontFace: "Aptos",
+      fontSize: 12,
+      color: COLORS.dim,
+      margin: 0,
+      fit: "shrink",
+    });
+  }
+}
+
+function addBody(slide, items, startY, maxHeight) {
+  if (!items.length) return startY;
+  slide.addText(items.map((item) => `• ${item}`).join("\n"), {
+    x: MARGIN_X,
+    y: startY,
+    w: 5.85,
+    h: maxHeight,
+    fontFace: "Aptos",
+    fontSize: items.length > 7 ? 12 : 14,
+    color: COLORS.text,
+    margin: 0.05,
+    fit: "shrink",
+  });
+  return startY + maxHeight + 0.2;
+}
+
+function addTables(slide, tables, startY) {
+  if (!tables.length) return;
+  const table = tables[0].slice(0, 9).map((row) => row.slice(0, 5));
+  const colCount = Math.max(...table.map((row) => row.length));
+  const rows = table.map((row) => Array.from({ length: colCount }, (_, index) => row[index] ?? ""));
+  slide.addTable(rows, {
+    x: 6.85,
+    y: startY,
+    w: 5.8,
+    h: 3.9,
+    colW: Array.from({ length: colCount }, () => 5.8 / colCount),
+    border: { type: "solid", pt: 0.5, color: COLORS.border },
+    color: COLORS.text,
+    fontFace: "Aptos",
+    fontSize: rows.length > 6 || colCount > 3 ? 8 : 10,
+    margin: 0.05,
+    valign: "top",
+  });
+}
+
+function addCode(slide, codeBlocks, startY) {
+  if (!codeBlocks.length) return;
+  slide.addText(codeBlocks[0], {
+    x: 6.85,
+    y: startY,
+    w: 5.8,
+    h: 3.9,
+    fontFace: "Courier New",
+    fontSize: 8,
+    color: COLORS.text,
+    fill: { color: COLORS.surface, transparency: 0 },
+    margin: 0.12,
+    fit: "shrink",
+  });
+}
+
+function addFallbackPanel(slide) {
+  slide.addText("Static export", {
+    x: 6.85,
+    y: 1.75,
+    w: 5.8,
+    h: 0.35,
+    fontFace: "Aptos",
+    fontSize: 12,
+    bold: true,
+    color: COLORS.accent,
+    margin: 0,
+  });
+  slide.addText("Use the HTML deck for animations, Mermaid rendering, reader navigation, custom fonts, and responsive layout.", {
+    x: 6.85,
+    y: 2.15,
+    w: 5.8,
+    h: 1.2,
+    fontFace: "Aptos",
+    fontSize: 13,
+    color: COLORS.dim,
+    margin: 0,
+    fit: "shrink",
+  });
+}
+
+function renderPptx(slides, outputPath) {
+  const pptx = new pptxgen();
+  pptx.layout = "LAYOUT_WIDE";
+  pptx.author = "visual-explainer";
+  pptx.company = "visual-explainer";
+  pptx.subject = "Best-effort static export from a visual-explainer HTML slide deck";
+  pptx.title = slides[0]?.title ?? "Visual Explainer Deck";
+  pptx.lang = "en-US";
+  pptx.theme = {
+    headFontFace: "Aptos Display",
+    bodyFontFace: "Aptos",
+    lang: "en-US",
+  };
+
+  slides.forEach((data, index) => {
+    const slide = pptx.addSlide();
+    slide.background = { color: COLORS.bg };
+    slide.addShape("rect", { x: 0, y: 0, w: SLIDE_W, h: SLIDE_H, fill: { color: COLORS.bg }, line: { color: COLORS.bg } });
+    slide.addShape("rect", { x: 0, y: 0, w: 0.16, h: SLIDE_H, fill: { color: COLORS.accent }, line: { color: COLORS.accent } });
+    addTitle(slide, data);
+    addBody(slide, data.body, 1.75, 4.8);
+    if (data.tables.length) addTables(slide, data.tables, 1.75);
+    else if (data.codeBlocks.length) addCode(slide, data.codeBlocks, 1.75);
+    else addFallbackPanel(slide);
+    addFooter(slide, index, slides.length);
+  });
+
+  return pptx.writeFile({ fileName: outputPath });
+}
+
+export async function exportPptx(inputPath, explicitOutputPath) {
+  if (!inputPath) throw new Error("input.html is required");
+  const outputPath = outputPathFor(inputPath, explicitOutputPath);
+  const html = await readFile(inputPath, "utf8");
+  const root = parse(html);
+  const slideSections = findSlideSections(root);
+  if (!slideSections.length) throw new Error("No slide sections found. Best-effort PPTX export expects a visual-explainer HTML deck with <section class=\"slide\"> elements.");
+  const slides = slideSections.map(extractSlide).filter((slide) => slide.title || slide.body.length || slide.tables.length || slide.codeBlocks.length);
+  if (!slides.length) throw new Error("No exportable slide content found.");
+  await mkdir(dirname(outputPath), { recursive: true });
+  await renderPptx(slides, outputPath);
+  return { inputPath, outputPath, slideCount: slides.length };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const [inputPath, outputPath] = args;
+  const result = await exportPptx(inputPath, outputPath);
+  process.stdout.write(`Wrote ${result.outputPath}\nSlides: ${result.slideCount}\nBest-effort static export. Use the HTML deck for full fidelity.\n`);
+}
+
+function isMainModule() {
+  return Boolean(process.argv[1] && realpathSync(process.argv[1]) === scriptPath);
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Adds optional best-effort PPTX export for simple visual-explainer HTML slide decks. The HTML deck remains the source of truth; the `.pptx` output is a static handoff for cases that require a presentation file.

The exporter extracts slide titles, short text, bullets, simple tables, code blocks, and Mermaid source placeholders from `<section class="slide">` elements. Docs call out unsupported fidelity for animations, reader navigation, responsive layout, custom web fonts, live Mermaid/Chart.js/SVG/canvas rendering, and JavaScript behavior.

Closes #50.

## Validation

- `node --check plugins/visual-explainer/pptx/export.mjs`
- `node --check plugins/visual-explainer/mcp/server.mjs`
- `node --check plugins/visual-explainer/quick/render.mjs`
- `node --check plugins/visual-explainer/extension.ts`
- package JSON dependency/bin assertions
- sample HTML deck export and `.pptx` zip inspection for title, bullets, table cells, code, and diagram placeholders
- `<pre class="mermaid">` regression export confirmed `Diagram source` and graph text in `.pptx` XML
- symlinked `visual-explainer-pptx` invocation wrote a valid `.pptx`
- non-slide HTML input failed with `No slide sections found`
- `--help` smoke
- `npm pack --dry-run`
- `git diff --check`
- fresh exact-head review: `reports/issue-50-pptx-best-effort-gate-review-b28b7e3.md`
