### PR TITLE
fix: sync marketplace plugin version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Plugin distribution for visual-explainer",
-    "version": "0.8.2",
+    "version": "0.9.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -13,7 +13,7 @@
       "name": "visual-explainer",
       "source": "./plugins/visual-explainer",
       "description": "Generate beautiful HTML pages for diagrams, diff reviews, plan reviews, slides, and data tables",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "author": {
         "name": "nicobailon"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Synchronized Claude Code marketplace and skill metadata versions to `0.9.0` after the mismatch reported by @romkazor in #83.
+
 ## [0.9.0] - 2026-08-13
 
 ### Added

--- a/plugins/visual-explainer/SKILL.md
+++ b/plugins/visual-explainer/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires a browser to view generated HTML files. Optional surf-cli for AI image generation.
 metadata:
   author: nicobailon
-  version: "0.8.2"
+  version: "0.9.0"
 ---
 
 # Visual Explainer


### PR DESCRIPTION
## Summary

Syncs the Claude Code marketplace catalog and skill metadata to `0.9.0` after the v0.9.0 release.

Closes #83.

## Validation

- `git diff --check`
- Node version assertions for package, plugin, marketplace, and skill metadata
- Fresh read-only review: No issues found

Credit: reported by @romkazor in #83.